### PR TITLE
Use correct content value for field name exports

### DIFF
--- a/redcaplite/api/field_names.py
+++ b/redcaplite/api/field_names.py
@@ -4,7 +4,7 @@ from .utils import optional_field
 @optional_field('field')
 def get_field_names(data):
     new_data = {
-        'content': 'userDagMapping',
+        'content': 'exportFieldNames',
         'format': 'json'
     }
     return (new_data)

--- a/tests/api/test_field_names.py
+++ b/tests/api/test_field_names.py
@@ -5,7 +5,7 @@ def test_get_field_names():
     # Test case 1: Field is present in the input data
     data = {'field': 'test_value'}
     expected_output = {
-        'content': 'userDagMapping',
+        'content': 'exportFieldNames',
         'format': 'json',
         'field': 'test_value'
     }
@@ -14,6 +14,6 @@ def test_get_field_names():
     # Test case 2: Field is absent in the input data
     data = {}
     expected_output = {
-        'content': 'userDagMapping', 'format': 'json'
+        'content': 'exportFieldNames', 'format': 'json'
     }
     assert get_field_names(data) == expected_output

--- a/tests/test_redcap.py
+++ b/tests/test_redcap.py
@@ -169,7 +169,7 @@ def test_redcap_client_get_field_names(client):
     """Test RedcapClient get_field_names method"""
     mock_redcap_client_post(
         client, 'get_field_names', method_kwargs={},
-        expected_requests_data={'content': 'userDagMapping',
+        expected_requests_data={'content': 'exportFieldNames',
                                 'format': 'json', 'returnFormat': 'json', 'token': 'token'},
     )
 


### PR DESCRIPTION
## Summary
- Fix `get_field_names` to send `content=exportFieldNames`
- Update tests to expect the `exportFieldNames` content value

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_689a2c7579ec833297662fd84b85253a