### PR TITLE
Fix typo in handler error message

### DIFF
--- a/redcaplite/http/handler.py
+++ b/redcaplite/http/handler.py
@@ -32,7 +32,7 @@ def response_error_handler(func):
             raise APIException(
                 "Not Implemented: The requested method is not implemented.")
         else:
-            raise Exception("Unkown issue.")
+            raise Exception("Unknown issue.")
     return wrapper
 
 

--- a/tests/http/test_handler.py
+++ b/tests/http/test_handler.py
@@ -91,7 +91,7 @@ def test_response_error_handler_unknown_status_code():
     decorated_func = response_error_handler(mock_func)
     with pytest.raises(Exception) as exc_info:
         decorated_func(None, {})
-    assert str(exc_info.value) == "Unkown issue."
+    assert str(exc_info.value) == "Unknown issue."
 
 
 def test_csv_handler():


### PR DESCRIPTION
## Summary
- fix typo in default exception message within HTTP handler
- update corresponding unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'redcaplite')*
- `pip install -q pandas requests` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_689a2c2ba1a08332bebe372e43fd7e22