### PR TITLE
Bump package version to 1.4.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,5 @@
+# Release Notes
+
+## 1.4.0
+
+- Bump package version to 1.4.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcaplite"
-version = "1.3.2"
+version = "1.4.0"
 authors = [
   { name="Jubilee Tan", email="jubilee2@gmail.com" },
 ]


### PR DESCRIPTION
## Summary
- Bump package version to 1.4.0
- Move release notes from README to new NEWS.md

## Testing
- `python -m pip install pandas` *(fails: Tunnel connection failed: 403 Forbidden)*
- `PYTHONPATH=. pytest --maxfail=1` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_689a30c9de388332a8f5b3640c6e3351