### PR TITLE
docs: highlight key features in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@
 ![PyPI - Version](https://img.shields.io/pypi/v/redcaplite)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/redcaplite)
 
-`redcaplite` is a Python package designed for straightforward interaction with the REDCap (Research Electronic Data Capture) API. This package provides user-friendly methods to communicate with various API endpoints.
+**Lightweight, user-friendly Python client for the REDCap API.**
+
+`redcaplite` makes it easy to connect to your REDCap project and perform common operations with minimal code. Whether you're a researcher automating data pulls or a developer building integrations, `redcaplite` keeps things simple and efficient.
+
+## Key Features
+
+-   Intuitive interface for the most common REDCap API endpoints.
+-   Installable from PyPI and ready to use in seconds.
+-   Fully typed and tested for reliable data exchange.
+-   Minimal dependencies to keep your environment lean.
 
 ## Prerequisites
 Before using `redcaplite`, you need to obtain two key pieces of information from your REDCap project's API page:


### PR DESCRIPTION
## Summary
- add a concise tagline and key feature list to README for clearer project positioning

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'redcaplite')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement hatchling)*

------
https://chatgpt.com/codex/tasks/task_e_689a366dae588332a9926bb25bf163ed