### PR TITLE
refactor: avoid mutable csv kwargs

### DIFF
--- a/redcaplite/http/handler.py
+++ b/redcaplite/http/handler.py
@@ -37,7 +37,9 @@ def response_error_handler(func):
 
 
 def csv_handler(func):
-    def wrapper(obj, data, pd_read_csv_kwargs={}):
+    def wrapper(obj, data, pd_read_csv_kwargs=None):
+        if pd_read_csv_kwargs is None:
+            pd_read_csv_kwargs = {}
         data['format'] = 'csv'
         response = func(obj, data)
         if 'returnContent' in data and data['returnContent'] == 'ids':


### PR DESCRIPTION
## Summary
- avoid mutable default kwargs in csv handler

## Testing
- `PYTHONPATH=. pytest tests/http/test_client.py tests/http/test_handler.py -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_689a38eb9cac833285d8ba45a67dced4