### PR TITLE
Handle custom read_csv kwargs per call

### DIFF
--- a/redcaplite/http/client.py
+++ b/redcaplite/http/client.py
@@ -1,4 +1,5 @@
 import requests
+from typing import Any, Dict, Optional
 import redcaplite.http.handler as hd
 
 
@@ -7,7 +8,14 @@ class Client:
         self.url = url
         self.token = token
 
-    def post(self, data, pd_read_csv_kwargs={}):
+    def post(
+            self,
+            data,
+            pd_read_csv_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        if pd_read_csv_kwargs is None:
+            pd_read_csv_kwargs = {}
+
         format = data.get("format", None)
         if format == 'csv':
             response = self.__csv_api(

--- a/redcaplite/http/handler.py
+++ b/redcaplite/http/handler.py
@@ -1,6 +1,7 @@
 from .error import APIException
 import os
 import io
+from typing import Any, Dict, Optional
 import pandas as pd
 
 
@@ -37,7 +38,14 @@ def response_error_handler(func):
 
 
 def csv_handler(func):
-    def wrapper(obj, data, pd_read_csv_kwargs={}):
+    def wrapper(
+            obj,
+            data,
+            pd_read_csv_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        if pd_read_csv_kwargs is None:
+            pd_read_csv_kwargs = {}
+
         data['format'] = 'csv'
         response = func(obj, data)
         if 'returnContent' in data and data['returnContent'] == 'ids':

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -37,6 +37,25 @@ def test_client_post_csv():
             {'format': 'csv'}, pd_read_csv_kwargs={"foo": []})
 
 
+def test_client_post_csv_kwargs_independent_between_calls():
+    """Ensure different pd_read_csv_kwargs do not share state across calls"""
+    client = Client('https://example.com', 'token')
+    mock_response = Mock()
+    with patch.object(client, '_Client__csv_api', return_value=mock_response) as mock_csv_api:
+        kwargs1 = {'foo': []}
+        kwargs2 = {'bar': []}
+
+        client.post({'format': 'csv'}, pd_read_csv_kwargs=kwargs1)
+        client.post({'format': 'csv'}, pd_read_csv_kwargs=kwargs2)
+
+        first_kwargs = mock_csv_api.call_args_list[0].kwargs['pd_read_csv_kwargs']
+        second_kwargs = mock_csv_api.call_args_list[1].kwargs['pd_read_csv_kwargs']
+
+        assert first_kwargs is kwargs1
+        assert second_kwargs is kwargs2
+        assert 'foo' in first_kwargs and 'foo' not in second_kwargs
+
+
 def test_client_post_default_format():
     """Test Client post method with default format"""
     client = Client('https://example.com', 'token')


### PR DESCRIPTION
## Summary
- allow passing custom pandas.read_csv options per Client.post call
- ensure csv_handler wrapper initializes read_csv kwargs safely
- add regression test ensuring kwargs state isn't shared across calls

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a38eccee48332b392dd5f2fe3ff54