### PR TITLE
Mark integration tests with pytest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,8 @@ Issues = "https://github.com/jubilee2/RedcapLite/issues"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: marks tests that require external services"
+]

--- a/tests/integration/test_arms_and_events_integration.py
+++ b/tests/integration/test_arms_and_events_integration.py
@@ -23,6 +23,7 @@ def client():
         pytest.skip("Integration test credentials not configured.")
     return RedcapClient(API_URL, API_TOKEN)
 
+@pytest.mark.integration
 def test_arm_and_event_integration(client):
     """
     Integration test for the REDCap 'arm' and 'event' APIs.

--- a/tests/integration/test_dag_integration.py
+++ b/tests/integration/test_dag_integration.py
@@ -28,6 +28,7 @@ def client():
     return RedcapClient(API_URL, API_TOKEN)
 
 
+@pytest.mark.integration
 def test_get_dags(client):
     """
     Tests the export of Data Access Groups (DAGs).
@@ -40,6 +41,7 @@ def test_get_dags(client):
     print("Exported DAGs:", dags)
 
 
+@pytest.mark.integration
 def test_import_and_delete_dags(client):
     """
     Tests the import and deletion of Data Access Groups (DAGs).


### PR DESCRIPTION
## Summary
- annotate integration tests with `@pytest.mark.integration`
- register `integration` marker in pytest config

## Testing
- `PYTHONPATH=$PWD pytest` *(fails: No module named 'pandas')*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68a29a1af5c08332b5fd7eed0fdfde0c