### PR TITLE
Add new CLI command modules for records, users, arms, events, project, survey, and files

### DIFF
--- a/redcaplite/cli/arms.py
+++ b/redcaplite/cli/arms.py
@@ -1,0 +1,89 @@
+"""Arms CLI command group definitions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from .helpers import ClientBootstrapError, build_client
+from .output import print_error, print_success, print_table
+
+_ARMS_SUBCOMMANDS = ("list", "export", "import", "delete")
+
+
+def register_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Attach the ``arms`` command group to the CLI root."""
+    parser = subparsers.add_parser(
+        "arms",
+        prog="rcl arms <profile>",
+        help="List and manage project arms.",
+        description="List and manage project arms.",
+    )
+    parser.add_argument("profile", metavar="<profile>", help="Profile name.")
+    arms_subparsers = parser.add_subparsers(dest="arms_command")
+    arms_subparsers.required = True
+
+    for name in _ARMS_SUBCOMMANDS:
+        command_parser = arms_subparsers.add_parser(name, prog=f"rcl arms <profile> {name}")
+        if name in {"list", "export"}:
+            command_parser.add_argument("--arm", dest="arms", action="append", type=int, help="Arm number filter.")
+            command_parser.set_defaults(handler=_handle_export_arms)
+            continue
+        if name == "import":
+            command_parser.add_argument("data_file", help="Path to JSON file with arm definitions.")
+            command_parser.set_defaults(handler=_handle_import_arms)
+            continue
+        if name == "delete":
+            command_parser.add_argument("arm_numbers", nargs="+", type=int, help="One or more arm numbers to delete.")
+            command_parser.set_defaults(handler=_handle_delete_arms)
+
+
+def _handle_export_arms(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        arms = client.get_arms(arms=args.arms or [])
+    except ClientBootstrapError as exc:
+        print_error(str(exc))
+        return 1
+
+    rows = _coerce_rows(arms)
+    if not rows:
+        print_success("No arms were returned.")
+        return 0
+    print_table(rows)
+    return 0
+
+
+def _handle_import_arms(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        with open(args.data_file, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        response = client.import_arms(payload)
+    except (ClientBootstrapError, OSError, ValueError) as exc:
+        print_error(str(exc))
+        return 1
+
+    print_success(f"Imported arms: {response}")
+    return 0
+
+
+def _handle_delete_arms(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        response = client.delete_arms(args.arm_numbers)
+    except ClientBootstrapError as exc:
+        print_error(str(exc))
+        return 1
+
+    print_success(f"Deleted arms: {response}")
+    return 0
+
+
+def _coerce_rows(rows: Any) -> list[dict[str, Any]]:
+    if isinstance(rows, list):
+        return [row if isinstance(row, dict) else {"value": row} for row in rows]
+    if isinstance(rows, dict):
+        return [rows]
+    return []

--- a/redcaplite/cli/events.py
+++ b/redcaplite/cli/events.py
@@ -1,0 +1,89 @@
+"""Events CLI command group definitions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from .helpers import ClientBootstrapError, build_client
+from .output import print_error, print_success, print_table
+
+_EVENTS_SUBCOMMANDS = ("list", "export", "import", "delete")
+
+
+def register_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Attach the ``events`` command group to the CLI root."""
+    parser = subparsers.add_parser(
+        "events",
+        prog="rcl events <profile>",
+        help="List and manage project events.",
+        description="List and manage project events.",
+    )
+    parser.add_argument("profile", metavar="<profile>", help="Profile name.")
+    events_subparsers = parser.add_subparsers(dest="events_command")
+    events_subparsers.required = True
+
+    for name in _EVENTS_SUBCOMMANDS:
+        command_parser = events_subparsers.add_parser(name, prog=f"rcl events <profile> {name}")
+        if name in {"list", "export"}:
+            command_parser.add_argument("--arm", dest="arms", action="append", type=int, help="Arm number filter.")
+            command_parser.set_defaults(handler=_handle_export_events)
+            continue
+        if name == "import":
+            command_parser.add_argument("data_file", help="Path to JSON file with event definitions.")
+            command_parser.set_defaults(handler=_handle_import_events)
+            continue
+        if name == "delete":
+            command_parser.add_argument("events", nargs="+", help="One or more event unique names to delete.")
+            command_parser.set_defaults(handler=_handle_delete_events)
+
+
+def _handle_export_events(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        events = client.get_events(arms=args.arms or [])
+    except ClientBootstrapError as exc:
+        print_error(str(exc))
+        return 1
+
+    rows = _coerce_rows(events)
+    if not rows:
+        print_success("No events were returned.")
+        return 0
+    print_table(rows)
+    return 0
+
+
+def _handle_import_events(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        with open(args.data_file, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        response = client.import_events(payload)
+    except (ClientBootstrapError, OSError, ValueError) as exc:
+        print_error(str(exc))
+        return 1
+
+    print_success(f"Imported events: {response}")
+    return 0
+
+
+def _handle_delete_events(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        response = client.delete_events(args.events)
+    except ClientBootstrapError as exc:
+        print_error(str(exc))
+        return 1
+
+    print_success(f"Deleted events: {response}")
+    return 0
+
+
+def _coerce_rows(rows: Any) -> list[dict[str, Any]]:
+    if isinstance(rows, list):
+        return [row if isinstance(row, dict) else {"value": row} for row in rows]
+    if isinstance(rows, dict):
+        return [rows]
+    return []

--- a/redcaplite/cli/files.py
+++ b/redcaplite/cli/files.py
@@ -1,0 +1,97 @@
+"""File upload CLI command group definitions."""
+
+from __future__ import annotations
+
+import argparse
+
+from .helpers import ClientBootstrapError, build_client
+from .output import print_error, print_success
+
+_FILES_SUBCOMMANDS = ("export", "import", "delete")
+
+
+def register_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Attach the ``files`` command group to the CLI root."""
+    parser = subparsers.add_parser(
+        "files",
+        prog="rcl files <profile>",
+        help="Export, import, or delete upload field files.",
+        description="Export, import, or delete upload field files.",
+    )
+    parser.add_argument("profile", metavar="<profile>", help="Profile name.")
+    files_subparsers = parser.add_subparsers(dest="files_command")
+    files_subparsers.required = True
+
+    for name in _FILES_SUBCOMMANDS:
+        command_parser = files_subparsers.add_parser(name, prog=f"rcl files <profile> {name}")
+        command_parser.add_argument("record", help="Record ID.")
+        command_parser.add_argument("field", help="File upload field name.")
+        command_parser.add_argument("--event", help="Event unique name.")
+        command_parser.add_argument("--repeat-instance", type=int, help="Repeat instance number.")
+        if name == "export":
+            command_parser.add_argument(
+                "--out-dir",
+                default="",
+                help="Directory to save the downloaded file.",
+            )
+            command_parser.set_defaults(handler=_handle_export_file)
+            continue
+        if name == "import":
+            command_parser.add_argument("file_path", help="Path to local file to upload.")
+            command_parser.set_defaults(handler=_handle_import_file)
+            continue
+        if name == "delete":
+            command_parser.set_defaults(handler=_handle_delete_file)
+
+
+def _handle_export_file(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        path = client.get_file(
+            record=args.record,
+            field=args.field,
+            event=args.event,
+            repeat_instance=args.repeat_instance,
+            file_dictionary=args.out_dir,
+        )
+    except ClientBootstrapError as exc:
+        print_error(str(exc))
+        return 1
+
+    print_success(f"Exported file: {path}")
+    return 0
+
+
+def _handle_import_file(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        response = client.import_file(
+            file_path=args.file_path,
+            record=args.record,
+            field=args.field,
+            event=args.event,
+            repeat_instance=args.repeat_instance,
+        )
+    except ClientBootstrapError as exc:
+        print_error(str(exc))
+        return 1
+
+    print_success(f"Imported file: {response}")
+    return 0
+
+
+def _handle_delete_file(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        response = client.delete_file(
+            record=args.record,
+            field=args.field,
+            event=args.event,
+            repeat_instance=args.repeat_instance,
+        )
+    except ClientBootstrapError as exc:
+        print_error(str(exc))
+        return 1
+
+    print_success(f"Deleted file: {response}")
+    return 0

--- a/redcaplite/cli/project.py
+++ b/redcaplite/cli/project.py
@@ -1,0 +1,72 @@
+"""Project CLI command group definitions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from .helpers import ClientBootstrapError, build_client
+from .output import print_error, print_success, print_table
+
+_PROJECT_SUBCOMMANDS = ("list", "export", "import")
+
+
+def register_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Attach the ``project`` command group to the CLI root."""
+    parser = subparsers.add_parser(
+        "project",
+        prog="rcl project <profile>",
+        help="Inspect and manage project settings.",
+        description="Inspect and manage project settings.",
+    )
+    parser.add_argument("profile", metavar="<profile>", help="Profile name.")
+    project_subparsers = parser.add_subparsers(dest="project_command")
+    project_subparsers.required = True
+
+    for name in _PROJECT_SUBCOMMANDS:
+        command_parser = project_subparsers.add_parser(name, prog=f"rcl project <profile> {name}")
+        if name in {"list", "export"}:
+            command_parser.set_defaults(handler=_handle_export_project)
+            continue
+        if name == "import":
+            command_parser.add_argument("data_file", help="Path to JSON file with project settings.")
+            command_parser.set_defaults(handler=_handle_import_project)
+
+
+def _handle_export_project(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        project = client.get_project()
+    except ClientBootstrapError as exc:
+        print_error(str(exc))
+        return 1
+
+    rows = _coerce_rows(project)
+    if not rows:
+        print_success("No project settings were returned.")
+        return 0
+    print_table(rows)
+    return 0
+
+
+def _handle_import_project(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        with open(args.data_file, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        response = client.import_project_settings(payload)
+    except (ClientBootstrapError, OSError, ValueError) as exc:
+        print_error(str(exc))
+        return 1
+
+    print_success(f"Imported project settings: {response}")
+    return 0
+
+
+def _coerce_rows(rows: Any) -> list[dict[str, Any]]:
+    if isinstance(rows, list):
+        return [row if isinstance(row, dict) else {"value": row} for row in rows]
+    if isinstance(rows, dict):
+        return [rows]
+    return []

--- a/redcaplite/cli/records.py
+++ b/redcaplite/cli/records.py
@@ -1,0 +1,112 @@
+"""Records CLI command group definitions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+import pandas as pd
+
+from .helpers import ClientBootstrapError, build_client
+from .output import print_error, print_success, print_table
+
+_RECORDS_SUBCOMMANDS = ("list", "export", "import", "delete")
+
+
+def register_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Attach the ``records`` command group to the CLI root."""
+    parser = subparsers.add_parser(
+        "records",
+        prog="rcl records <profile>",
+        help="List and manage project records.",
+        description="List and manage project records.",
+    )
+    parser.add_argument("profile", metavar="<profile>", help="Profile name.")
+    records_subparsers = parser.add_subparsers(dest="records_command")
+    records_subparsers.required = True
+
+    for name in _RECORDS_SUBCOMMANDS:
+        command_parser = records_subparsers.add_parser(name, prog=f"rcl records <profile> {name}")
+        if name in {"list", "export"}:
+            command_parser.add_argument("--record", dest="records", action="append", help="Record ID filter.")
+            command_parser.add_argument("--field", dest="fields", action="append", help="Field name filter.")
+            command_parser.add_argument("--form", dest="forms", action="append", help="Form name filter.")
+            command_parser.add_argument("--event", dest="events", action="append", help="Event name filter.")
+            command_parser.set_defaults(handler=_handle_export_records)
+            continue
+        if name == "import":
+            command_parser.add_argument("data_file", help="Path to JSON or CSV file to import.")
+            command_parser.add_argument(
+                "--format",
+                choices=("json", "csv"),
+                default="csv",
+                help="Input format for import payload.",
+            )
+            command_parser.set_defaults(handler=_handle_import_records)
+            continue
+        if name == "delete":
+            command_parser.add_argument("record_ids", nargs="+", help="One or more record IDs to delete.")
+            command_parser.set_defaults(handler=_handle_delete_records)
+
+
+def _handle_export_records(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        rows = client.export_records(
+            format="csv",
+            records=args.records or [],
+            fields=args.fields or [],
+            forms=args.forms or [],
+            events=args.events or [],
+        )
+    except ClientBootstrapError as exc:
+        print_error(str(exc))
+        return 1
+
+    table_rows = _coerce_rows(rows)
+    if not table_rows:
+        print_success("No records were returned.")
+        return 0
+    print_table(table_rows)
+    return 0
+
+
+def _handle_import_records(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        payload: Any
+        if args.format == "json":
+            with open(args.data_file, "r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+        else:
+            payload = pd.read_csv(args.data_file)
+        response = client.import_records(payload, format=args.format)
+    except (ClientBootstrapError, OSError, ValueError) as exc:
+        print_error(str(exc))
+        return 1
+
+    print_success(f"Imported records: {response}")
+    return 0
+
+
+def _handle_delete_records(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        response = client.delete_records(args.record_ids)
+    except ClientBootstrapError as exc:
+        print_error(str(exc))
+        return 1
+
+    print_success(f"Deleted records: {response}")
+    return 0
+
+
+def _coerce_rows(rows: Any) -> list[dict[str, Any]]:
+    if isinstance(rows, pd.DataFrame):
+        return rows.to_dict(orient="records")
+    if isinstance(rows, list):
+        return [row if isinstance(row, dict) else {"value": row} for row in rows]
+    if isinstance(rows, dict):
+        return [rows]
+    return [{"value": rows}]

--- a/redcaplite/cli/registry.py
+++ b/redcaplite/cli/registry.py
@@ -5,9 +5,21 @@ from __future__ import annotations
 from collections.abc import Iterator
 from types import ModuleType
 
-from . import metadata, profiles, setup, sync
+from . import arms, events, files, metadata, profiles, project, records, setup, survey, sync, users
 
-_COMMAND_MODULES: tuple[ModuleType, ...] = (setup, metadata, sync, profiles)
+_COMMAND_MODULES: tuple[ModuleType, ...] = (
+    setup,
+    metadata,
+    records,
+    users,
+    arms,
+    events,
+    project,
+    survey,
+    files,
+    sync,
+    profiles,
+)
 
 
 def iter_command_modules() -> Iterator[ModuleType]:

--- a/redcaplite/cli/survey.py
+++ b/redcaplite/cli/survey.py
@@ -1,0 +1,116 @@
+"""Survey CLI command group definitions."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+from .helpers import ClientBootstrapError, build_client
+from .output import print_error, print_success, print_table
+
+_SURVEY_SUBCOMMANDS = ("participants", "link", "queue-link", "return-code")
+
+
+def register_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Attach the ``survey`` command group to the CLI root."""
+    parser = subparsers.add_parser(
+        "survey",
+        prog="rcl survey <profile>",
+        help="Access survey participant and link tools.",
+        description="Access survey participant and link tools.",
+    )
+    parser.add_argument("profile", metavar="<profile>", help="Profile name.")
+    survey_subparsers = parser.add_subparsers(dest="survey_command")
+    survey_subparsers.required = True
+
+    for name in _SURVEY_SUBCOMMANDS:
+        command_parser = survey_subparsers.add_parser(name, prog=f"rcl survey <profile> {name}")
+        if name == "participants":
+            command_parser.add_argument("instrument", help="Instrument unique name.")
+            command_parser.add_argument("--event", help="Event unique name.")
+            command_parser.set_defaults(handler=_handle_participant_list)
+            continue
+        if name == "link":
+            command_parser.add_argument("record", help="Record ID.")
+            command_parser.add_argument("instrument", help="Instrument unique name.")
+            command_parser.add_argument("--event", help="Event unique name.")
+            command_parser.add_argument("--repeat-instance", type=int, help="Repeat instance number.")
+            command_parser.set_defaults(handler=_handle_survey_link)
+            continue
+        if name == "queue-link":
+            command_parser.add_argument("record", help="Record ID.")
+            command_parser.set_defaults(handler=_handle_queue_link)
+            continue
+        if name == "return-code":
+            command_parser.add_argument("record", help="Record ID.")
+            command_parser.add_argument("instrument", help="Instrument unique name.")
+            command_parser.add_argument("--event", help="Event unique name.")
+            command_parser.add_argument("--repeat-instance", type=int, help="Repeat instance number.")
+            command_parser.set_defaults(handler=_handle_return_code)
+
+
+def _handle_participant_list(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        participants = client.get_participant_list(instrument=args.instrument, event=args.event, format="csv")
+    except ClientBootstrapError as exc:
+        print_error(str(exc))
+        return 1
+
+    rows = _coerce_rows(participants)
+    if not rows:
+        print_success("No survey participants were returned.")
+        return 0
+    print_table(rows)
+    return 0
+
+
+def _handle_survey_link(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        link = client.get_survey_link(
+            record=args.record,
+            instrument=args.instrument,
+            event=args.event,
+            repeat_instance=args.repeat_instance,
+        )
+    except ClientBootstrapError as exc:
+        print_error(str(exc))
+        return 1
+    print_success(str(link))
+    return 0
+
+
+def _handle_queue_link(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        link = client.get_survey_queue_link(record=args.record)
+    except ClientBootstrapError as exc:
+        print_error(str(exc))
+        return 1
+    print_success(str(link))
+    return 0
+
+
+def _handle_return_code(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        code = client.get_survey_return_code(
+            record=args.record,
+            instrument=args.instrument,
+            event=args.event,
+            repeat_instance=args.repeat_instance,
+        )
+    except ClientBootstrapError as exc:
+        print_error(str(exc))
+        return 1
+    print_success(str(code))
+    return 0
+
+
+def _coerce_rows(rows: Any) -> list[dict[str, Any]]:
+    if isinstance(rows, list):
+        return [row if isinstance(row, dict) else {"value": row} for row in rows]
+    if isinstance(rows, dict):
+        return [rows]
+    return []

--- a/redcaplite/cli/users.py
+++ b/redcaplite/cli/users.py
@@ -1,0 +1,88 @@
+"""Users CLI command group definitions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from .helpers import ClientBootstrapError, build_client
+from .output import print_error, print_success, print_table
+
+_USERS_SUBCOMMANDS = ("list", "export", "import", "delete")
+
+
+def register_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Attach the ``users`` command group to the CLI root."""
+    parser = subparsers.add_parser(
+        "users",
+        prog="rcl users <profile>",
+        help="List and manage project users.",
+        description="List and manage project users.",
+    )
+    parser.add_argument("profile", metavar="<profile>", help="Profile name.")
+    users_subparsers = parser.add_subparsers(dest="users_command")
+    users_subparsers.required = True
+
+    for name in _USERS_SUBCOMMANDS:
+        command_parser = users_subparsers.add_parser(name, prog=f"rcl users <profile> {name}")
+        if name in {"list", "export"}:
+            command_parser.set_defaults(handler=_handle_export_users)
+            continue
+        if name == "import":
+            command_parser.add_argument("data_file", help="Path to JSON file with users to import.")
+            command_parser.set_defaults(handler=_handle_import_users)
+            continue
+        if name == "delete":
+            command_parser.add_argument("usernames", nargs="+", help="One or more usernames to delete.")
+            command_parser.set_defaults(handler=_handle_delete_users)
+
+
+def _handle_export_users(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        users = client.get_users()
+    except ClientBootstrapError as exc:
+        print_error(str(exc))
+        return 1
+
+    rows = _coerce_rows(users)
+    if not rows:
+        print_success("No users were returned.")
+        return 0
+    print_table(rows)
+    return 0
+
+
+def _handle_import_users(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        with open(args.data_file, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        response = client.import_users(payload)
+    except (ClientBootstrapError, OSError, ValueError) as exc:
+        print_error(str(exc))
+        return 1
+
+    print_success(f"Imported users: {response}")
+    return 0
+
+
+def _handle_delete_users(args: argparse.Namespace) -> int:
+    try:
+        client = build_client(args.profile)
+        response = client.delete_users(args.usernames)
+    except ClientBootstrapError as exc:
+        print_error(str(exc))
+        return 1
+
+    print_success(f"Deleted users: {response}")
+    return 0
+
+
+def _coerce_rows(rows: Any) -> list[dict[str, Any]]:
+    if isinstance(rows, list):
+        return [row if isinstance(row, dict) else {"value": row} for row in rows]
+    if isinstance(rows, dict):
+        return [rows]
+    return []

--- a/tests/cli/test_root.py
+++ b/tests/cli/test_root.py
@@ -7,9 +7,14 @@ def test_main_without_args_prints_help(capsys) -> None:
     assert main([]) == 0
 
     captured = capsys.readouterr()
-    assert "usage: rcl [-h] {setup,metadata,sync,profiles} ..." in captured.out
+    assert (
+        "usage: rcl [-h] {setup,metadata,records,users,arms,events,project,survey,files,sync,profiles} ..."
+        in captured.out
+    )
     assert "setup" in captured.out
     assert "metadata" in captured.out
+    assert "records" in captured.out
+    assert "users" in captured.out
     assert "sync" in captured.out
 
 
@@ -27,7 +32,10 @@ def test_main_with_root_help_flag_prints_root_help(capsys) -> None:
     assert main(["--help"]) == 0
 
     captured = capsys.readouterr()
-    assert "usage: rcl [-h] {setup,metadata,sync,profiles} ..." in captured.out
+    assert (
+        "usage: rcl [-h] {setup,metadata,records,users,arms,events,project,survey,files,sync,profiles} ..."
+        in captured.out
+    )
     assert "Create or update stored access for a REDCap profile." in captured.out
     assert "sync" in captured.out
     assert captured.err == ""
@@ -192,3 +200,35 @@ def test_build_parser_supports_profiles_command() -> None:
 
     assert parsed.command == "profiles"
     assert callable(parsed.handler)
+
+
+def test_build_parser_supports_records_command() -> None:
+    parser = build_parser()
+
+    parsed = parser.parse_args(["records", "demo", "list", "--record", "1"])
+
+    assert parsed.command == "records"
+    assert parsed.profile == "demo"
+    assert parsed.records_command == "list"
+    assert parsed.records == ["1"]
+
+
+def test_build_parser_supports_users_command() -> None:
+    parser = build_parser()
+
+    parsed = parser.parse_args(["users", "demo", "delete", "alice"])
+
+    assert parsed.command == "users"
+    assert parsed.profile == "demo"
+    assert parsed.users_command == "delete"
+    assert parsed.usernames == ["alice"]
+
+
+def test_build_parser_supports_project_command() -> None:
+    parser = build_parser()
+
+    parsed = parser.parse_args(["project", "demo", "export"])
+
+    assert parsed.command == "project"
+    assert parsed.profile == "demo"
+    assert parsed.project_command == "export"


### PR DESCRIPTION
### Motivation
- Expose common REDCap resources via the `rcl` CLI using the same command-group pattern as existing `metadata` and `sync` modules so operators can list/export/import/delete core objects from the command line (records, users, arms, events, project settings, survey tools, and file uploads).【F:redcaplite/cli/records.py†L17-L36】【F:redcaplite/cli/registry.py†L10-L21】
- Provide a minimal vertical slice per resource: read/export (list) commands first, and add import/delete handlers where the `RedcapClient` API supports them to enable iterative feature rollout.【F:redcaplite/cli/users.py†L27-L35】【F:redcaplite/cli/arms.py†L27-L35】

### Description
- Added new CLI modules `redcaplite/cli/records.py`, `redcaplite/cli/users.py`, `redcaplite/cli/arms.py`, `redcaplite/cli/events.py`, `redcaplite/cli/project.py`, `redcaplite/cli/survey.py`, and `redcaplite/cli/files.py`, each implementing `register_parser(subparsers)` and handlers for export/list and import/delete where applicable.【F:redcaplite/cli/records.py†L1-L14】【F:redcaplite/cli/files.py†L13-L23】
- All modules use `build_client(profile)` from `redcaplite/cli/helpers.py` and reuse `print_error`, `print_success`, and `print_table` output helpers for consistent CLI behaviour.【F:redcaplite/cli/records.py†L53-L63】【F:redcaplite/cli/helpers.py†L1-L20】
- Registered the new modules in `redcaplite/cli/registry.py` so they appear in root help and are iterated by `build_parser()`; ordering was chosen to keep setup/metadata first and profiles last.【F:redcaplite/cli/registry.py†L8-L21】
- Updated CLI parser tests in `tests/cli/test_root.py` to reflect the expanded top-level usage and added representative parser assertions for `records`, `users`, and `project` commands.【F:tests/cli/test_root.py†L10-L13】【F:tests/cli/test_root.py†L205-L233】

### Testing
- Ran the full test suite with `pytest` after adding the modules and test adjustments, and all automated tests passed: `218 passed, 21 skipped`. (See `pytest` output summary.)
- Verified root parser behaviour and the newly added parser tests in `tests/cli/test_root.py` executed successfully as part of the test run.【F:tests/cli/test_root.py†L6-L18】【pytest output: 218 passed, 21 skipped】

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c781a8d9108332aaf70398cc2ec68a)