### PR TITLE
Sync DAGs as part of `rcl sync` operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 - Switched root/setup/metadata help output back to default argparse-generated `usage` formatting.
 - Corrected `rcl sync` parser `prog` formatting so positional arguments are not duplicated in generated help usage output.
 - Standardized `prog` values for `setup` and `metadata` to base command names so error messages avoid placeholder-style command prefixes.
+- Updated `rcl sync` to compare/import DAG configuration alongside metadata so profile sync operations copy data access groups as well.
 
 ## [2.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 - Updated `rcl sync` to compare/import DAG configuration alongside metadata so profile sync operations copy data access groups as well.
 - Refactored sync comparison output to reuse the shared table-print helper for both metadata and DAG preview sections.
 - Made sync comparison table columns explicit at each call site, removing implicit default column selection.
+- Simplified DAG sync record conversion by inlining DataFrame-to-record transformations instead of a dedicated helper.
 
 ## [2.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 - Standardized `prog` values for `setup` and `metadata` to base command names so error messages avoid placeholder-style command prefixes.
 - Updated `rcl sync` to compare/import DAG configuration alongside metadata so profile sync operations copy data access groups as well.
 - Refactored sync comparison output to reuse the shared table-print helper for both metadata and DAG preview sections.
+- Made sync comparison table columns explicit at each call site, removing implicit default column selection.
 
 ## [2.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 - Corrected `rcl sync` parser `prog` formatting so positional arguments are not duplicated in generated help usage output.
 - Standardized `prog` values for `setup` and `metadata` to base command names so error messages avoid placeholder-style command prefixes.
 - Updated `rcl sync` to compare/import DAG configuration alongside metadata so profile sync operations copy data access groups as well.
+- Refactored sync comparison output to reuse the shared table-print helper for both metadata and DAG preview sections.
 
 ## [2.2.1]
 

--- a/README.md
+++ b/README.md
@@ -170,12 +170,12 @@ The metadata sync workflow is a top-level command:
 rcl sync <source_profile> <target_profile> [--yes] [--dry-run] [--backup-file path]
 ```
 
-Use `sync` when you want to compare full metadata exports between two saved profiles and optionally import the source metadata into the target project after review.
+Use `sync` when you want to compare full metadata exports (plus DAG assignments) between two saved profiles and optionally import the source configuration into the target project after review.
 
 Available today:
 
-- `sync <source_profile> <target_profile> [--yes]` exports metadata from both profiles, derives source-only and target-only row sets with paired DataFrame-based all-column anti-joins for review, and then optionally imports the source profile metadata into the target profile
-- `--dry-run` previews differences but never imports metadata
+- `sync <source_profile> <target_profile> [--yes]` exports metadata and DAGs from both profiles, derives source-only and target-only row sets with paired DataFrame-based all-column anti-joins for review, and then optionally imports source metadata and source DAGs into the target profile
+- `--dry-run` previews differences but never imports metadata or DAGs
 - `--backup-file path` exports the target metadata CSV before import to support rollback/audit workflows
 
 Internally, `redcaplite.metadata_ops.transform` and `redcaplite.metadata_ops.validate` now provide the reusable add/edit/remove helpers for metadata write workflows, including CLI flag-to-row conversion, field-type validation, light choice-field validation, default label generation, and DataFrame-based append/update/remove helpers.

--- a/redcaplite/cli/sync.py
+++ b/redcaplite/cli/sync.py
@@ -107,14 +107,17 @@ def run_sync(
     _print_comparison_table(
         "Fields to add in target:",
         metadata_to_records(adds),
+        columns=["field_name", "form_name", "field_type"],
     )
     _print_comparison_table(
         "Fields to update in target:",
         metadata_to_records(updates),
+        columns=["field_name", "form_name", "field_type"],
     )
     _print_comparison_table(
         "Fields to remove from target:",
         metadata_to_records(removals),
+        columns=["field_name", "form_name", "field_type"],
     )
     _print_comparison_table(
         "DAGs to add in target:",
@@ -260,7 +263,7 @@ def _rows_to_records(rows: pd.DataFrame) -> list[dict[str, Any]]:
 def _print_comparison_table(
     title: str,
     rows: list[dict[str, Any]],
-    columns: list[str] | None = None,
+    columns: list[str],
 ) -> None:
     """Print a titled comparison section."""
     print_preview([title])
@@ -272,8 +275,7 @@ def _print_comparison_table(
 
 def _comparison_table_rows(
     rows: list[dict[str, Any]],
-    columns: list[str] | None = None,
+    columns: list[str],
 ) -> list[dict[str, Any]]:
     """Reduce comparison rows to the columns shown in sync output."""
-    columns = columns or ["field_name", "form_name", "field_type"]
     return [{column: row.get(column, "") for column in columns} for row in rows]

--- a/redcaplite/cli/sync.py
+++ b/redcaplite/cli/sync.py
@@ -73,6 +73,8 @@ def run_sync(
         target_client = build_client(target_profile)
         source_metadata = source_client.get_metadata(format="csv")
         target_metadata = target_client.get_metadata(format="csv")
+        source_dags = _normalize_dag_rows(source_client.get_dags())
+        target_dags = _normalize_dag_rows(target_client.get_dags())
     except ClientBootstrapError as exc:
         print_error(str(exc))
         return 1
@@ -81,6 +83,10 @@ def run_sync(
     updates = comparison["updates"]
     adds = comparison["adds"]
     removals = comparison["removals"]
+    dag_comparison = compare_dags(source_dags, target_dags)
+    dag_adds = dag_comparison["adds"]
+    dag_updates = dag_comparison["updates"]
+    dag_removals = dag_comparison["removals"]
 
     print_preview(
         [
@@ -91,6 +97,11 @@ def run_sync(
             f"Adds: {len(adds.index)}",
             f"Updates: {len(updates.index)}",
             f"Removals: {len(removals.index)}",
+            f"Source DAGs: {len(source_dags.index)}",
+            f"Target DAGs: {len(target_dags.index)}",
+            f"DAG adds: {len(dag_adds.index)}",
+            f"DAG updates: {len(dag_updates.index)}",
+            f"DAG removals: {len(dag_removals.index)}",
         ]
     )
     _print_comparison_table(
@@ -105,9 +116,21 @@ def run_sync(
         "Fields to remove from target:",
         metadata_to_records(removals),
     )
+    _print_dag_comparison_table(
+        "DAGs to add in target:",
+        _rows_to_records(dag_adds),
+    )
+    _print_dag_comparison_table(
+        "DAGs to update in target:",
+        _rows_to_records(dag_updates),
+    )
+    _print_dag_comparison_table(
+        "DAGs to remove from target:",
+        _rows_to_records(dag_removals),
+    )
 
-    if adds.empty and updates.empty and removals.empty:
-        print_success(f'No metadata differences found between "{source_profile}" and "{target_profile}".')
+    if adds.empty and updates.empty and removals.empty and dag_adds.empty and dag_updates.empty and dag_removals.empty:
+        print_success(f'No metadata or DAG differences found between "{source_profile}" and "{target_profile}".')
         return 0
 
     if dry_run:
@@ -127,6 +150,8 @@ def run_sync(
 
     target_client.import_metadata(source_metadata, format="csv")
     print_success(f'Imported metadata from "{source_profile}" into "{target_profile}".')
+    target_client.import_dags(_rows_to_records(source_dags))
+    print_success(f'Imported DAGs from "{source_profile}" into "{target_profile}".')
     return 0
 
 
@@ -140,6 +165,24 @@ def compare_metadata(
     updates = target_only.merge(source_only[["field_name"]], how="inner", on="field_name")
     source_only = source_only.merge(updates[["field_name"]], how="left_anti", on=["field_name"])
     target_only = target_only.merge(updates[["field_name"]], how="left_anti", on=["field_name"])
+
+    return {
+        "adds": source_only,
+        "updates": updates,
+        "removals": target_only,
+    }
+
+
+def compare_dags(
+    source_dags: pd.DataFrame,
+    target_dags: pd.DataFrame,
+) -> dict[str, pd.DataFrame]:
+    """Return DAG differences as additions, updates, and removals."""
+    source_only = _left_anti_rows(source_dags, target_dags)
+    target_only = _left_anti_rows(target_dags, source_dags)
+    updates = target_only.merge(source_only[["unique_group_name"]], how="inner", on="unique_group_name")
+    source_only = source_only.merge(updates[["unique_group_name"]], how="left_anti", on=["unique_group_name"])
+    target_only = target_only.merge(updates[["unique_group_name"]], how="left_anti", on=["unique_group_name"])
 
     return {
         "adds": source_only,
@@ -186,6 +229,31 @@ def _normalize_backup_file_path(backup_file: str) -> Path:
         return backup_path / f"target_metadata_backup_{timestamp}.csv"
     return backup_path
 
+
+def _normalize_dag_rows(raw_dags: Any) -> pd.DataFrame:
+    """Return DAG rows using importable columns in a stable order."""
+    if isinstance(raw_dags, pd.DataFrame):
+        dag_rows = raw_dags.copy()
+    else:
+        dag_rows = pd.DataFrame(raw_dags or [])
+
+    if dag_rows.empty:
+        return pd.DataFrame(columns=["data_access_group_name", "unique_group_name"])
+
+    for column in ("data_access_group_name", "unique_group_name"):
+        if column not in dag_rows.columns:
+            dag_rows[column] = ""
+
+    return dag_rows[["data_access_group_name", "unique_group_name"]]
+
+
+def _rows_to_records(rows: pd.DataFrame) -> list[dict[str, Any]]:
+    """Convert any row-based DataFrame to records for display/import."""
+    if rows.empty:
+        return []
+    return rows.fillna("").to_dict(orient="records")
+
+
 def _print_comparison_table(title: str, rows: list[dict[str, Any]]) -> None:
     """Print a titled comparison section."""
     print_preview([title])
@@ -198,4 +266,19 @@ def _print_comparison_table(title: str, rows: list[dict[str, Any]]) -> None:
 def _comparison_table_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Reduce comparison rows to the columns shown in sync output."""
     columns = ["field_name", "form_name", "field_type"]
+    return [{column: row.get(column, "") for column in columns} for row in rows]
+
+
+def _print_dag_comparison_table(title: str, rows: list[dict[str, Any]]) -> None:
+    """Print a titled DAG comparison section."""
+    print_preview([title])
+    if not rows:
+        print_preview(["  (none)"])
+        return
+    print_table(_dag_comparison_table_rows(rows))
+
+
+def _dag_comparison_table_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Reduce DAG comparison rows to the columns shown in sync output."""
+    columns = ["unique_group_name", "data_access_group_name"]
     return [{column: row.get(column, "") for column in columns} for row in rows]

--- a/redcaplite/cli/sync.py
+++ b/redcaplite/cli/sync.py
@@ -121,17 +121,17 @@ def run_sync(
     )
     _print_comparison_table(
         "DAGs to add in target:",
-        _rows_to_records(dag_adds),
+        dag_adds.fillna("").to_dict(orient="records"),
         columns=["unique_group_name", "data_access_group_name"],
     )
     _print_comparison_table(
         "DAGs to update in target:",
-        _rows_to_records(dag_updates),
+        dag_updates.fillna("").to_dict(orient="records"),
         columns=["unique_group_name", "data_access_group_name"],
     )
     _print_comparison_table(
         "DAGs to remove from target:",
-        _rows_to_records(dag_removals),
+        dag_removals.fillna("").to_dict(orient="records"),
         columns=["unique_group_name", "data_access_group_name"],
     )
 
@@ -156,7 +156,7 @@ def run_sync(
 
     target_client.import_metadata(source_metadata, format="csv")
     print_success(f'Imported metadata from "{source_profile}" into "{target_profile}".')
-    target_client.import_dags(_rows_to_records(source_dags))
+    target_client.import_dags(source_dags.fillna("").to_dict(orient="records"))
     print_success(f'Imported DAGs from "{source_profile}" into "{target_profile}".')
     return 0
 
@@ -251,13 +251,6 @@ def _normalize_dag_rows(raw_dags: Any) -> pd.DataFrame:
             dag_rows[column] = ""
 
     return dag_rows[["data_access_group_name", "unique_group_name"]]
-
-
-def _rows_to_records(rows: pd.DataFrame) -> list[dict[str, Any]]:
-    """Convert any row-based DataFrame to records for display/import."""
-    if rows.empty:
-        return []
-    return rows.fillna("").to_dict(orient="records")
 
 
 def _print_comparison_table(

--- a/redcaplite/cli/sync.py
+++ b/redcaplite/cli/sync.py
@@ -116,17 +116,20 @@ def run_sync(
         "Fields to remove from target:",
         metadata_to_records(removals),
     )
-    _print_dag_comparison_table(
+    _print_comparison_table(
         "DAGs to add in target:",
         _rows_to_records(dag_adds),
+        columns=["unique_group_name", "data_access_group_name"],
     )
-    _print_dag_comparison_table(
+    _print_comparison_table(
         "DAGs to update in target:",
         _rows_to_records(dag_updates),
+        columns=["unique_group_name", "data_access_group_name"],
     )
-    _print_dag_comparison_table(
+    _print_comparison_table(
         "DAGs to remove from target:",
         _rows_to_records(dag_removals),
+        columns=["unique_group_name", "data_access_group_name"],
     )
 
     if adds.empty and updates.empty and removals.empty and dag_adds.empty and dag_updates.empty and dag_removals.empty:
@@ -254,31 +257,23 @@ def _rows_to_records(rows: pd.DataFrame) -> list[dict[str, Any]]:
     return rows.fillna("").to_dict(orient="records")
 
 
-def _print_comparison_table(title: str, rows: list[dict[str, Any]]) -> None:
+def _print_comparison_table(
+    title: str,
+    rows: list[dict[str, Any]],
+    columns: list[str] | None = None,
+) -> None:
     """Print a titled comparison section."""
     print_preview([title])
     if not rows:
         print_preview(["  (none)"])
         return
-    print_table(_comparison_table_rows(rows))
+    print_table(_comparison_table_rows(rows, columns=columns))
 
 
-def _comparison_table_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _comparison_table_rows(
+    rows: list[dict[str, Any]],
+    columns: list[str] | None = None,
+) -> list[dict[str, Any]]:
     """Reduce comparison rows to the columns shown in sync output."""
-    columns = ["field_name", "form_name", "field_type"]
-    return [{column: row.get(column, "") for column in columns} for row in rows]
-
-
-def _print_dag_comparison_table(title: str, rows: list[dict[str, Any]]) -> None:
-    """Print a titled DAG comparison section."""
-    print_preview([title])
-    if not rows:
-        print_preview(["  (none)"])
-        return
-    print_table(_dag_comparison_table_rows(rows))
-
-
-def _dag_comparison_table_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Reduce DAG comparison rows to the columns shown in sync output."""
-    columns = ["unique_group_name", "data_access_group_name"]
+    columns = columns or ["field_name", "form_name", "field_type"]
     return [{column: row.get(column, "") for column in columns} for row in rows]

--- a/tests/cli/fakes.py
+++ b/tests/cli/fakes.py
@@ -17,6 +17,7 @@ class MetadataClient(FakeClient):
         super().__init__(url, token)
         self.imported_metadata: pd.DataFrame | None = None
         self.imported_format: str | None = None
+        self.imported_dags: list[dict[str, str]] | None = None
         self.exported_metadata_output_file: str | None = None
         self._metadata = [
             {
@@ -34,6 +35,7 @@ class MetadataClient(FakeClient):
                 "required_field": "",
             },
         ]
+        self._dags = []
 
     def get_metadata(
         self,
@@ -58,11 +60,25 @@ class MetadataClient(FakeClient):
         self.imported_format = format
         return "1"
 
+    def get_dags(self) -> list[dict[str, str]]:
+        return self._dags
+
+    def import_dags(self, data: list[dict[str, str]]) -> str:
+        self.imported_dags = data
+        return "1"
+
 
 class SyncMetadataClient(MetadataClient):
-    def __init__(self, url: str, token: str, metadata: list[dict[str, str]]) -> None:
+    def __init__(
+        self,
+        url: str,
+        token: str,
+        metadata: list[dict[str, str]],
+        dags: list[dict[str, str]] | None = None,
+    ) -> None:
         super().__init__(url, token)
         self._metadata = metadata
+        self._dags = dags or []
 
 
 class FailingClient(FakeClient):

--- a/tests/cli/test_sync.py
+++ b/tests/cli/test_sync.py
@@ -79,13 +79,18 @@ def test_main_sync_prints_differences_and_imports_source_metadata(monkeypatch, c
     assert "age" in captured.out
     assert "Fields to remove from target:" in captured.out
     assert "weight" in captured.out
+    assert "DAGs to add in target:" in captured.out
+    assert "DAGs to update in target:" in captured.out
+    assert "DAGs to remove from target:" in captured.out
     assert "field_name" in captured.out
     assert "form_name" in captured.out
     assert "field_type" in captured.out
     assert "field_label" not in captured.out
     assert "Weight" not in captured.out
     assert 'Imported metadata from "profile1" into "profile2".' in captured.out
+    assert 'Imported DAGs from "profile1" into "profile2".' in captured.out
     assert target_client.imported_metadata is not None
+    assert target_client.imported_dags == []
     assert list(target_client.imported_metadata["field_name"]) == ["record_id", "age", "height"]
     assert captured.err == ""
 
@@ -147,9 +152,35 @@ def test_main_sync_reports_when_metadata_matches(monkeypatch, capsys) -> None:
     assert main(["sync", "profile1", "profile2"]) == 0
 
     captured = capsys.readouterr()
-    assert 'No metadata differences found between "profile1" and "profile2".' in captured.out
+    assert 'No metadata or DAG differences found between "profile1" and "profile2".' in captured.out
     assert target_client.imported_metadata is None
     assert captured.err == ""
+
+
+def test_main_sync_copies_dags(monkeypatch, capsys) -> None:
+    source_client = SyncMetadataClient(
+        "https://source.example.edu/api/",
+        "source-token",
+        metadata=[{"field_name": "record_id", "form_name": "enrollment", "field_type": "text", "field_label": "Record ID"}],
+        dags=[{"data_access_group_name": "Site A", "unique_group_name": "site_a"}],
+    )
+    target_client = SyncMetadataClient(
+        "https://target.example.edu/api/",
+        "target-token",
+        metadata=[{"field_name": "record_id", "form_name": "enrollment", "field_type": "text", "field_label": "Record ID"}],
+        dags=[],
+    )
+    monkeypatch.setattr(
+        "redcaplite.cli.sync.build_client",
+        lambda profile: source_client if profile == "profile1" else target_client,
+    )
+
+    assert main(["sync", "profile1", "profile2", "--yes"]) == 0
+
+    captured = capsys.readouterr()
+    assert "DAG adds: 1" in captured.out
+    assert "site_a" in captured.out
+    assert target_client.imported_dags == [{"data_access_group_name": "Site A", "unique_group_name": "site_a"}]
 
 
 def test_compare_metadata_uses_source_only_field_names_for_updates() -> None:


### PR DESCRIPTION
### Motivation
- Extend the `rcl sync` workflow so profile syncs also consider and copy Data Access Groups (DAGs) in addition to metadata, providing a single reviewed import flow for both metadata and DAG configuration.

### Description
- Load DAG lists from source and target via `get_dags()` and normalize them with a new `_normalize_dag_rows` helper inside `redcaplite/cli/sync.py`, then compute DAG adds/updates/removals with a new `compare_dags` function and preview them alongside metadata differences.
- Convert DAG row-frames to simple record lists for display/import with `_rows_to_records`, print DAG preview tables with `_print_dag_comparison_table`/`_dag_comparison_table_rows`, and import source DAGs into the target by calling `target_client.import_dags` after metadata import.
- Add DAG support to test doubles and tests by extending `tests/cli/fakes.py` with `get_dags`/`import_dags` and DAG state, and update/add expectations in `tests/cli/test_sync.py` to validate DAG preview and copy behavior.
- Update user-facing docs and release notes by editing `README.md` and `CHANGELOG.md` to document that `rcl sync` compares/imports DAGs and that `--dry-run` skips both metadata and DAG imports.

### Testing
- Ran `pytest` during the rollout (an initial run failed because DAG rows were incorrectly passed through `metadata_to_records`, which was fixed in a follow-up change).  
- Final test run shows all tests passing with `220 passed, 21 skipped`, including the updated `tests/cli/test_sync.py` (see test summary printed by `pytest`).

Modified files: `redcaplite/cli/sync.py`, `tests/cli/fakes.py`, `tests/cli/test_sync.py`, `README.md`, `CHANGELOG.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de5fbfad248330abc92f5e21381af9)