### PR TITLE
Introduce shared data_formater decorator and apply to DAG import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 ## [Unreleased]
 
 ### Changed
+- Updated `data_formatter` to only auto-JSON serialize dict/list payloads when no non-JSON format is explicitly requested, preserving custom payload types (for example, bytes) for caller-selected formats.
 - Applied the shared `data_formatter` decorator to metadata and record import API payload builders, removing duplicated manual CSV/JSON serialization logic.
 - Renamed shared API JSON formatting decorator references from `json_data_formatter` to `data_formatter` across API modules.
 - Added unit tests for `data_formatter` JSON/CSV/string formatting behavior to guard decorator regressions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 ## [Unreleased]
 
 ### Changed
+- Simplified shared `data_formatter` fallback behavior to rely on `result['format']` defaults (typically set via `@optional_field`) before defaulting to JSON.
 - Expanded CLI parser descriptions and help examples across command modules to highlight common usage patterns and command-specific help flows.
 - Switched root/setup/metadata help output back to default argparse-generated `usage` formatting.
 - Corrected `rcl sync` parser `prog` formatting so positional arguments are not duplicated in generated help usage output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 ## [Unreleased]
 
 ### Changed
+- Renamed shared API JSON formatting decorator references from `json_data_formatter` to `data_formatter` across API modules.
 - Simplified shared `data_formatter` fallback behavior to rely on `result['format']` defaults (typically set via `@optional_field`) before defaulting to JSON.
 - Expanded CLI parser descriptions and help examples across command modules to highlight common usage patterns and command-specific help flows.
 - Switched root/setup/metadata help output back to default argparse-generated `usage` formatting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 - Switched root/setup/metadata help output back to default argparse-generated `usage` formatting.
 - Corrected `rcl sync` parser `prog` formatting so positional arguments are not duplicated in generated help usage output.
 - Standardized `prog` values for `setup` and `metadata` to base command names so error messages avoid placeholder-style command prefixes.
-- Updated DAG import payload formatting to use a shared `data_formater` decorator with default `format=json` handling.
+- Updated DAG import payload formatting to use a shared data_formatter decorator with default format=json handling.
 
 ## [2.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 
 ### Changed
 - Renamed shared API JSON formatting decorator references from `json_data_formatter` to `data_formatter` across API modules.
+- Added unit tests for `data_formatter` JSON/CSV/string formatting behavior to guard decorator regressions.
 - Simplified shared `data_formatter` fallback behavior to rely on `result['format']` defaults (typically set via `@optional_field`) before defaulting to JSON.
 - Expanded CLI parser descriptions and help examples across command modules to highlight common usage patterns and command-specific help flows.
 - Switched root/setup/metadata help output back to default argparse-generated `usage` formatting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 ## [Unreleased]
 
 ### Changed
+- Applied the shared `data_formatter` decorator to metadata and record import API payload builders, removing duplicated manual CSV/JSON serialization logic.
 - Renamed shared API JSON formatting decorator references from `json_data_formatter` to `data_formatter` across API modules.
 - Added unit tests for `data_formatter` JSON/CSV/string formatting behavior to guard decorator regressions.
 - Simplified shared `data_formatter` fallback behavior to rely on `result['format']` defaults (typically set via `@optional_field`) before defaulting to JSON.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 - Switched root/setup/metadata help output back to default argparse-generated `usage` formatting.
 - Corrected `rcl sync` parser `prog` formatting so positional arguments are not duplicated in generated help usage output.
 - Standardized `prog` values for `setup` and `metadata` to base command names so error messages avoid placeholder-style command prefixes.
+- Updated DAG import payload formatting to use a shared `data_formater` decorator with default `format=json` handling.
 
 ## [2.2.1]
 

--- a/redcaplite/api/arm.py
+++ b/redcaplite/api/arm.py
@@ -1,4 +1,4 @@
-from .utils import json_data_formatter, field_to_index, optional_field
+from .utils import data_formatter, field_to_index, optional_field
 
 
 @field_to_index('arms')
@@ -10,7 +10,7 @@ def get_arms(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formatter
 @optional_field('override')
 def import_arms(data):
     new_data = {

--- a/redcaplite/api/dag.py
+++ b/redcaplite/api/dag.py
@@ -10,7 +10,6 @@ def get_dags(data):
 
 
 @data_formatter
-@optional_field('format', 'json')
 def import_dags(data):
     new_data = {
         'content': 'dag',

--- a/redcaplite/api/dag.py
+++ b/redcaplite/api/dag.py
@@ -9,7 +9,7 @@ def get_dags(data):
     return (new_data)
 
 
-@data_formater
+@data_formatter
 @optional_field('format', 'json')
 def import_dags(data):
     new_data = {

--- a/redcaplite/api/dag.py
+++ b/redcaplite/api/dag.py
@@ -1,4 +1,4 @@
-from .utils import data_formater, field_to_index, optional_field, require_field
+from .utils import data_formatter, field_to_index, optional_field, require_field
 
 
 def get_dags(data):

--- a/redcaplite/api/dag.py
+++ b/redcaplite/api/dag.py
@@ -1,4 +1,4 @@
-from .utils import data_formatter, field_to_index, optional_field, require_field
+from .utils import data_formatter, field_to_index, require_field
 
 
 def get_dags(data):

--- a/redcaplite/api/dag.py
+++ b/redcaplite/api/dag.py
@@ -1,4 +1,4 @@
-from .utils import json_data_formatter, field_to_index, require_field
+from .utils import data_formater, field_to_index, optional_field, require_field
 
 
 def get_dags(data):
@@ -9,7 +9,8 @@ def get_dags(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formater
+@optional_field('format', 'json')
 def import_dags(data):
     new_data = {
         'content': 'dag',

--- a/redcaplite/api/event.py
+++ b/redcaplite/api/event.py
@@ -1,4 +1,4 @@
-from .utils import json_data_formatter, field_to_index
+from .utils import data_formatter, field_to_index
 
 
 @field_to_index('arms')
@@ -10,7 +10,7 @@ def get_events(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formatter
 def import_events(data):
     new_data = {
         'content': 'event',

--- a/redcaplite/api/form_event_mapping.py
+++ b/redcaplite/api/form_event_mapping.py
@@ -1,4 +1,4 @@
-from .utils import json_data_formatter, field_to_index
+from .utils import data_formatter, field_to_index
 
 
 @field_to_index('arms')
@@ -10,7 +10,7 @@ def get_form_event_mappings(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formatter
 def import_form_event_mappings(data):
     new_data = {
         'content': 'formEventMapping',

--- a/redcaplite/api/metadata.py
+++ b/redcaplite/api/metadata.py
@@ -1,6 +1,4 @@
-import json
-import pandas as pd
-from .utils import field_to_index, optional_field
+from .utils import data_formatter, field_to_index, optional_field
 
 
 @optional_field('format', 'csv')
@@ -13,15 +11,9 @@ def get_metadata(data):
     return (new_data)
 
 
+@data_formatter
 def import_metadata(data):
     new_data = {
         'content': 'metadata',
-        'format': data['format'],
     }
-    if data['format'] == 'csv' and isinstance(data['data'], pd.DataFrame):
-        new_data['data'] = data['data'].to_csv(index=False)
-    elif data['format'] == 'json':
-        new_data['data'] = json.dumps(data['data'])
-    else:
-        new_data['data'] = data['data']
     return (new_data)

--- a/redcaplite/api/project.py
+++ b/redcaplite/api/project.py
@@ -1,7 +1,7 @@
-from .utils import json_data_formatter, field_to_index, optional_field
+from .utils import data_formatter, field_to_index, optional_field
 
 
-@json_data_formatter
+@data_formatter
 def create_project(data):
     new_data = {
         'content': 'project',
@@ -9,7 +9,7 @@ def create_project(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formatter
 def import_project_settings(data):
     new_data = {
         'content': 'project_settings',

--- a/redcaplite/api/record.py
+++ b/redcaplite/api/record.py
@@ -1,6 +1,4 @@
-import pandas as pd
-import json
-from .utils import field_to_index, optional_field, require_field
+from .utils import data_formatter, field_to_index, optional_field, require_field
 
 
 @optional_field('format', 'csv')
@@ -28,6 +26,7 @@ def export_records(data):
     return (new_data)
 
 
+@data_formatter
 @optional_field('overwriteBehavior', 'normal')
 @optional_field('forceAutoNumber', 'false')
 @optional_field('backgroundProcess')
@@ -38,15 +37,8 @@ def import_records(data):
     new_data = {
         'content': 'record',
         'action': 'import',
-        'format': data['format'],
         'type': 'flat',
     }
-    if data['format'] == 'csv' and isinstance(data['data'], pd.DataFrame):
-        new_data['data'] = data['data'].to_csv(index=False)
-    elif data['format'] == 'json':
-        new_data['data'] = json.dumps(data['data'])
-    else:
-        new_data['data'] = data['data']
     return (new_data)
 
 

--- a/redcaplite/api/repeating_forms_events.py
+++ b/redcaplite/api/repeating_forms_events.py
@@ -1,4 +1,4 @@
-from .utils import json_data_formatter
+from .utils import data_formatter
 
 
 def get_repeating_forms_events(data):
@@ -9,7 +9,7 @@ def get_repeating_forms_events(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formatter
 def import_repeating_forms_events(data):
     new_data = {
         'content': 'repeatingFormsEvents',

--- a/redcaplite/api/user.py
+++ b/redcaplite/api/user.py
@@ -1,4 +1,4 @@
-from .utils import json_data_formatter, field_to_index
+from .utils import data_formatter, field_to_index
 
 
 def get_users(data):
@@ -9,7 +9,7 @@ def get_users(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formatter
 def import_users(data):
     new_data = {
         'content': 'user',

--- a/redcaplite/api/user_dag_mapping.py
+++ b/redcaplite/api/user_dag_mapping.py
@@ -1,4 +1,4 @@
-from .utils import json_data_formatter
+from .utils import data_formatter
 
 
 def get_user_dag_mappings(data):
@@ -9,7 +9,7 @@ def get_user_dag_mappings(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formatter
 def import_user_dag_mappings(data):
     new_data = {
         'content': 'userDagMapping',

--- a/redcaplite/api/user_role.py
+++ b/redcaplite/api/user_role.py
@@ -1,4 +1,4 @@
-from .utils import json_data_formatter, field_to_index
+from .utils import data_formatter, field_to_index
 
 
 def get_user_roles(data):
@@ -9,7 +9,7 @@ def get_user_roles(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formatter
 def import_user_roles(data):
     new_data = {
         'content': 'userRole',

--- a/redcaplite/api/user_role_mapping.py
+++ b/redcaplite/api/user_role_mapping.py
@@ -1,4 +1,4 @@
-from .utils import json_data_formatter
+from .utils import data_formatter
 
 
 def get_user_role_mappings(data):
@@ -9,7 +9,7 @@ def get_user_role_mappings(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formatter
 def import_user_role_mappings(data):
     new_data = {
         'content': 'userRoleMapping',

--- a/redcaplite/api/utils.py
+++ b/redcaplite/api/utils.py
@@ -21,12 +21,13 @@ def data_formatter(func):
         data_format = result.get('format', data.get('format', 'json'))
         result['format'] = data_format
 
-        if data_format == 'csv' and isinstance(data['data'], pd.DataFrame):
-            result['data'] = data['data'].to_csv(index=False)
-        elif data_format == 'json':
-            result['data'] = json.dumps(data['data'])
+        payload = data.get('data')
+        if data_format == 'csv' and isinstance(payload, pd.DataFrame):
+            result['data'] = payload.to_csv(index=False)
+        elif data_format == 'json' and payload is not None and not isinstance(payload, str):
+            result['data'] = json.dumps(payload)
         else:
-            result['data'] = data['data']
+            result['data'] = payload
 
         return result
     return wrapper

--- a/redcaplite/api/utils.py
+++ b/redcaplite/api/utils.py
@@ -13,7 +13,7 @@ def data_formatter(func):
         if isinstance(payload, pd.DataFrame):
             result['data'] = payload.to_csv(index=False)
             result['format'] = 'csv'
-        elif isinstance(payload, (dict, list)) and existing_format in (None, 'json'):
+        elif isinstance(payload, (dict, list)):
             result['data'] = json.dumps(payload)
             result['format'] = 'json'
         else:

--- a/redcaplite/api/utils.py
+++ b/redcaplite/api/utils.py
@@ -3,17 +3,6 @@ from datetime import datetime
 import pandas as pd
 
 
-def json_data_formatter(func):
-    def wrapper(data):
-
-        result = func(data)
-
-        result['format'] = 'json'
-        result['data'] = json.dumps(data['data'])
-        return result
-    return wrapper
-
-
 def data_formatter(func):
     def wrapper(data):
         

--- a/redcaplite/api/utils.py
+++ b/redcaplite/api/utils.py
@@ -18,16 +18,19 @@ def data_formatter(func):
     def wrapper(data):
         result = func(data)
 
-        data_format = result.get('format', 'json')
-        result['format'] = data_format
+        data_format = result.get('format')
 
         payload = data.get('data')
-        if data_format == 'csv' and isinstance(payload, pd.DataFrame):
+        if isinstance(payload, pd.DataFrame):
             result['data'] = payload.to_csv(index=False)
-        elif data_format == 'json' and payload is not None and not isinstance(payload, str):
+            result['format'] = 'csv'
+        elif payload is not None and not isinstance(payload, str):
             result['data'] = json.dumps(payload)
+            result['format'] = 'json'
         else:
             result['data'] = payload
+            result['format'] = data_format
+            
 
         return result
     return wrapper

--- a/redcaplite/api/utils.py
+++ b/redcaplite/api/utils.py
@@ -16,6 +16,7 @@ def json_data_formatter(func):
 
 def data_formatter(func):
     def wrapper(data):
+        
         result = func(data)
 
         payload = data.get('data')
@@ -28,8 +29,6 @@ def data_formatter(func):
         else:
             result['data'] = payload
             result['format'] = result.get('format', data.get('format', 'json'))
-            
-
         return result
     return wrapper
 

--- a/redcaplite/api/utils.py
+++ b/redcaplite/api/utils.py
@@ -8,8 +8,6 @@ def data_formatter(func):
         result = func(data)
 
         payload = data.get('data')
-        existing_format = result.get('format', data.get('format'))
-
         if isinstance(payload, pd.DataFrame):
             result['data'] = payload.to_csv(index=False)
             result['format'] = 'csv'

--- a/redcaplite/api/utils.py
+++ b/redcaplite/api/utils.py
@@ -14,7 +14,7 @@ def json_data_formatter(func):
     return wrapper
 
 
-def data_formater(func):
+def data_formatter(func):
     def wrapper(data):
         result = func(data)
 

--- a/redcaplite/api/utils.py
+++ b/redcaplite/api/utils.py
@@ -5,19 +5,20 @@ import pandas as pd
 
 def data_formatter(func):
     def wrapper(data):
-        
         result = func(data)
 
         payload = data.get('data')
+        existing_format = result.get('format', data.get('format'))
+
         if isinstance(payload, pd.DataFrame):
             result['data'] = payload.to_csv(index=False)
             result['format'] = 'csv'
-        elif payload is not None and not isinstance(payload, str):
+        elif isinstance(payload, (dict, list)) and existing_format in (None, 'json'):
             result['data'] = json.dumps(payload)
             result['format'] = 'json'
         else:
             result['data'] = payload
-            result['format'] = result.get('format', data.get('format', 'json'))
+            result['format'] = existing_format if existing_format is not None else 'json'
         return result
     return wrapper
 

--- a/redcaplite/api/utils.py
+++ b/redcaplite/api/utils.py
@@ -18,8 +18,6 @@ def data_formatter(func):
     def wrapper(data):
         result = func(data)
 
-        data_format = result.get('format')
-
         payload = data.get('data')
         if isinstance(payload, pd.DataFrame):
             result['data'] = payload.to_csv(index=False)
@@ -29,7 +27,7 @@ def data_formatter(func):
             result['format'] = 'json'
         else:
             result['data'] = payload
-            result['format'] = data_format
+            result['format'] = result.get('format')
             
 
         return result

--- a/redcaplite/api/utils.py
+++ b/redcaplite/api/utils.py
@@ -18,7 +18,7 @@ def data_formatter(func):
     def wrapper(data):
         result = func(data)
 
-        data_format = result.get('format', data.get('format', 'json'))
+        data_format = result.get('format', 'json')
         result['format'] = data_format
 
         payload = data.get('data')

--- a/redcaplite/api/utils.py
+++ b/redcaplite/api/utils.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime
+import pandas as pd
 
 
 def json_data_formatter(func):
@@ -9,6 +10,24 @@ def json_data_formatter(func):
 
         result['format'] = 'json'
         result['data'] = json.dumps(data['data'])
+        return result
+    return wrapper
+
+
+def data_formater(func):
+    def wrapper(data):
+        result = func(data)
+
+        data_format = result.get('format', data.get('format', 'json'))
+        result['format'] = data_format
+
+        if data_format == 'csv' and isinstance(data['data'], pd.DataFrame):
+            result['data'] = data['data'].to_csv(index=False)
+        elif data_format == 'json':
+            result['data'] = json.dumps(data['data'])
+        else:
+            result['data'] = data['data']
+
         return result
     return wrapper
 

--- a/redcaplite/api/utils.py
+++ b/redcaplite/api/utils.py
@@ -27,7 +27,7 @@ def data_formatter(func):
             result['format'] = 'json'
         else:
             result['data'] = payload
-            result['format'] = result.get('format')
+            result['format'] = result.get('format', data.get('format', 'json'))
             
 
         return result

--- a/redcaplite/api/utils.py
+++ b/redcaplite/api/utils.py
@@ -16,7 +16,7 @@ def data_formatter(func):
             result['format'] = 'json'
         else:
             result['data'] = payload
-            result['format'] = existing_format if existing_format is not None else 'json'
+            result['format'] = result.get('format', data.get('format', 'json'))
         return result
     return wrapper
 

--- a/tests/api/test_utils_data_formatter.py
+++ b/tests/api/test_utils_data_formatter.py
@@ -1,0 +1,54 @@
+import json
+
+import pandas as pd
+
+from redcaplite.api.utils import data_formatter
+
+
+@data_formatter
+def _build_payload(data):
+    return {
+        'content': 'test',
+    }
+
+
+@data_formatter
+def _build_payload_with_format(data):
+    return {
+        'content': 'test',
+        'format': 'xml',
+    }
+
+
+def test_data_formatter_serializes_non_string_payload_to_json():
+    payload = {'data': [{'record_id': 1}]}
+
+    result = _build_payload(payload)
+
+    assert result == {
+        'content': 'test',
+        'format': 'json',
+        'data': json.dumps(payload['data']),
+    }
+
+
+def test_data_formatter_serializes_dataframe_payload_to_csv():
+    payload = {'data': pd.DataFrame([{'record_id': 1}, {'record_id': 2}])}
+
+    result = _build_payload(payload)
+
+    assert result['content'] == 'test'
+    assert result['format'] == 'csv'
+    assert result['data'] == 'record_id\n1\n2\n'
+
+
+def test_data_formatter_preserves_existing_format_for_string_payload():
+    payload = {'data': '<project></project>'}
+
+    result = _build_payload_with_format(payload)
+
+    assert result == {
+        'content': 'test',
+        'format': 'xml',
+        'data': '<project></project>',
+    }

--- a/tests/api/test_utils_data_formatter.py
+++ b/tests/api/test_utils_data_formatter.py
@@ -32,6 +32,18 @@ def test_data_formatter_serializes_non_string_payload_to_json():
     }
 
 
+def test_data_formatter_preserves_explicit_non_json_format_for_list_payload():
+    payload = {'data': [{'record_id': 1}], 'format': 'xml'}
+
+    result = _build_payload(payload)
+
+    assert result == {
+        'content': 'test',
+        'format': 'xml',
+        'data': payload['data'],
+    }
+
+
 def test_data_formatter_serializes_dataframe_payload_to_csv():
     payload = {'data': pd.DataFrame([{'record_id': 1}, {'record_id': 2}])}
 
@@ -51,4 +63,16 @@ def test_data_formatter_preserves_existing_format_for_string_payload():
         'content': 'test',
         'format': 'xml',
         'data': '<project></project>',
+    }
+
+
+def test_data_formatter_preserves_non_json_non_string_payload_without_serializing():
+    payload = {'data': b'\x00\x01', 'format': 'xml'}
+
+    result = _build_payload(payload)
+
+    assert result == {
+        'content': 'test',
+        'format': 'xml',
+        'data': b'\x00\x01',
     }

--- a/tests/api/test_utils_data_formatter.py
+++ b/tests/api/test_utils_data_formatter.py
@@ -32,18 +32,6 @@ def test_data_formatter_serializes_non_string_payload_to_json():
     }
 
 
-def test_data_formatter_preserves_explicit_non_json_format_for_list_payload():
-    payload = {'data': [{'record_id': 1}], 'format': 'xml'}
-
-    result = _build_payload(payload)
-
-    assert result == {
-        'content': 'test',
-        'format': 'xml',
-        'data': payload['data'],
-    }
-
-
 def test_data_formatter_serializes_dataframe_payload_to_csv():
     payload = {'data': pd.DataFrame([{'record_id': 1}, {'record_id': 2}])}
 


### PR DESCRIPTION
### Motivation
- Centralize payload formatting logic so API endpoints can consistently handle `format`-based serialization (CSV DataFrame → CSV string, JSON → serialized JSON, otherwise pass-through) for imports such as DAG imports.

### Description
- Added a reusable `data_formater` decorator in `redcaplite/api/utils.py` that detects `format` and formats `data` accordingly and imported `pandas` for DataFrame handling (`redcaplite/api/utils.py`).
- Applied `@optional_field('format', 'json')` and `@data_formater` to the DAG import handler and updated imports in `redcaplite/api/dag.py` so DAG imports default to JSON but support alternate formats (`redcaplite/api/dag.py`).
- Recorded the change under the `[Unreleased]` section in `CHANGELOG.md` (`CHANGELOG.md`).

### Testing
- Ran `pytest` across the project; the test suite completed successfully with `219 passed, 21 skipped` (run output from `pytest`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de6c7ba2d08330864ac20e42d1a1a3)