### PR TITLE
Make sync comparison table columns configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 - Switched root/setup/metadata help output back to default argparse-generated `usage` formatting.
 - Corrected `rcl sync` parser `prog` formatting so positional arguments are not duplicated in generated help usage output.
 - Standardized `prog` values for `setup` and `metadata` to base command names so error messages avoid placeholder-style command prefixes.
+- Updated sync comparison table helpers to accept caller-provided display columns for CLI output formatting.
 
 ## [2.2.1]
 

--- a/redcaplite/cli/sync.py
+++ b/redcaplite/cli/sync.py
@@ -96,14 +96,17 @@ def run_sync(
     _print_comparison_table(
         "Fields to add in target:",
         metadata_to_records(adds),
+        columns=["field_name", "form_name", "field_type"],
     )
     _print_comparison_table(
         "Fields to update in target:",
         metadata_to_records(updates),
+        columns=["field_name", "form_name", "field_type"],
     )
     _print_comparison_table(
         "Fields to remove from target:",
         metadata_to_records(removals),
+        columns=["field_name", "form_name", "field_type"],
     )
 
     if adds.empty and updates.empty and removals.empty:
@@ -186,16 +189,22 @@ def _normalize_backup_file_path(backup_file: str) -> Path:
         return backup_path / f"target_metadata_backup_{timestamp}.csv"
     return backup_path
 
-def _print_comparison_table(title: str, rows: list[dict[str, Any]]) -> None:
+def _print_comparison_table(
+    title: str,
+    rows: list[dict[str, Any]],
+    columns: list[str],
+) -> None:
     """Print a titled comparison section."""
     print_preview([title])
     if not rows:
         print_preview(["  (none)"])
         return
-    print_table(_comparison_table_rows(rows))
+    print_table(_comparison_table_rows(rows, columns=columns))
 
 
-def _comparison_table_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _comparison_table_rows(
+    rows: list[dict[str, Any]],
+    columns: list[str],
+) -> list[dict[str, Any]]:
     """Reduce comparison rows to the columns shown in sync output."""
-    columns = ["field_name", "form_name", "field_type"]
     return [{column: row.get(column, "") for column in columns} for row in rows]


### PR DESCRIPTION
### Motivation
- Allow the sync CLI comparison helpers to display caller-controlled columns instead of using a hard-coded column list to make output formatting flexible for different contexts and future changes. 【F:redcaplite/cli/sync.py†L192-L210】

### Description
- Changed `_print_comparison_table` to accept a `columns: list[str]` parameter and forward it to `_comparison_table_rows`. 【F:redcaplite/cli/sync.py†L192-L202】
- Updated `_comparison_table_rows` to accept `columns: list[str]` and use the caller-provided list instead of overwriting it internally. 【F:redcaplite/cli/sync.py†L205-L210】
- Updated all `run_sync` call sites to pass `columns=["field_name", "form_name", "field_type"]` for add/update/remove tables. 【F:redcaplite/cli/sync.py†L96-L110】
- Documented the change in `CHANGELOG.md` under the `[Unreleased]` section. 【F:CHANGELOG.md†L9-L14】

### Testing
- Ran the full test suite with `pytest`, which completed successfully with `219 passed, 21 skipped`. 【T:pytest (219 passed, 21 skipped)】

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de6cd21c4083309a292cc57237883a)