### PR TITLE
Rename json_data_formatter to data_formatter across API modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 ## [Unreleased]
 
 ### Changed
+- Renamed shared API JSON formatting decorator references from `json_data_formatter` to `data_formatter` across API modules.
 - Simplified shared `data_formatter` fallback behavior to rely on `result['format']` defaults (typically set via `@optional_field`) before defaulting to JSON.
 - Expanded CLI parser descriptions and help examples across command modules to highlight common usage patterns and command-specific help flows.
 - Switched root/setup/metadata help output back to default argparse-generated `usage` formatting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 
 ### Changed
 - Renamed shared API JSON formatting decorator references from `json_data_formatter` to `data_formatter` across API modules.
+- Added unit tests for `data_formatter` JSON/CSV/string formatting behavior to guard decorator regressions.
 - Simplified shared `data_formatter` fallback behavior to rely on `result['format']` defaults (typically set via `@optional_field`) before defaulting to JSON.
 - Expanded CLI parser descriptions and help examples across command modules to highlight common usage patterns and command-specific help flows.
 - Switched root/setup/metadata help output back to default argparse-generated `usage` formatting.

--- a/redcaplite/api/arm.py
+++ b/redcaplite/api/arm.py
@@ -1,4 +1,4 @@
-from .utils import json_data_formatter, field_to_index, optional_field
+from .utils import data_formatter, field_to_index, optional_field
 
 
 @field_to_index('arms')
@@ -10,7 +10,7 @@ def get_arms(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formatter
 @optional_field('override')
 def import_arms(data):
     new_data = {

--- a/redcaplite/api/event.py
+++ b/redcaplite/api/event.py
@@ -1,4 +1,4 @@
-from .utils import json_data_formatter, field_to_index
+from .utils import data_formatter, field_to_index
 
 
 @field_to_index('arms')
@@ -10,7 +10,7 @@ def get_events(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formatter
 def import_events(data):
     new_data = {
         'content': 'event',

--- a/redcaplite/api/form_event_mapping.py
+++ b/redcaplite/api/form_event_mapping.py
@@ -1,4 +1,4 @@
-from .utils import json_data_formatter, field_to_index
+from .utils import data_formatter, field_to_index
 
 
 @field_to_index('arms')
@@ -10,7 +10,7 @@ def get_form_event_mappings(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formatter
 def import_form_event_mappings(data):
     new_data = {
         'content': 'formEventMapping',

--- a/redcaplite/api/project.py
+++ b/redcaplite/api/project.py
@@ -1,7 +1,7 @@
-from .utils import json_data_formatter, field_to_index, optional_field
+from .utils import data_formatter, field_to_index, optional_field
 
 
-@json_data_formatter
+@data_formatter
 def create_project(data):
     new_data = {
         'content': 'project',
@@ -9,7 +9,7 @@ def create_project(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formatter
 def import_project_settings(data):
     new_data = {
         'content': 'project_settings',

--- a/redcaplite/api/repeating_forms_events.py
+++ b/redcaplite/api/repeating_forms_events.py
@@ -1,4 +1,4 @@
-from .utils import json_data_formatter
+from .utils import data_formatter
 
 
 def get_repeating_forms_events(data):
@@ -9,7 +9,7 @@ def get_repeating_forms_events(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formatter
 def import_repeating_forms_events(data):
     new_data = {
         'content': 'repeatingFormsEvents',

--- a/redcaplite/api/user.py
+++ b/redcaplite/api/user.py
@@ -1,4 +1,4 @@
-from .utils import json_data_formatter, field_to_index
+from .utils import data_formatter, field_to_index
 
 
 def get_users(data):
@@ -9,7 +9,7 @@ def get_users(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formatter
 def import_users(data):
     new_data = {
         'content': 'user',

--- a/redcaplite/api/user_dag_mapping.py
+++ b/redcaplite/api/user_dag_mapping.py
@@ -1,4 +1,4 @@
-from .utils import json_data_formatter
+from .utils import data_formatter
 
 
 def get_user_dag_mappings(data):
@@ -9,7 +9,7 @@ def get_user_dag_mappings(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formatter
 def import_user_dag_mappings(data):
     new_data = {
         'content': 'userDagMapping',

--- a/redcaplite/api/user_role.py
+++ b/redcaplite/api/user_role.py
@@ -1,4 +1,4 @@
-from .utils import json_data_formatter, field_to_index
+from .utils import data_formatter, field_to_index
 
 
 def get_user_roles(data):
@@ -9,7 +9,7 @@ def get_user_roles(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formatter
 def import_user_roles(data):
     new_data = {
         'content': 'userRole',

--- a/redcaplite/api/user_role_mapping.py
+++ b/redcaplite/api/user_role_mapping.py
@@ -1,4 +1,4 @@
-from .utils import json_data_formatter
+from .utils import data_formatter
 
 
 def get_user_role_mappings(data):
@@ -9,7 +9,7 @@ def get_user_role_mappings(data):
     return (new_data)
 
 
-@json_data_formatter
+@data_formatter
 def import_user_role_mappings(data):
     new_data = {
         'content': 'userRoleMapping',

--- a/redcaplite/api/utils.py
+++ b/redcaplite/api/utils.py
@@ -3,17 +3,6 @@ from datetime import datetime
 import pandas as pd
 
 
-def json_data_formatter(func):
-    def wrapper(data):
-
-        result = func(data)
-
-        result['format'] = 'json'
-        result['data'] = json.dumps(data['data'])
-        return result
-    return wrapper
-
-
 def data_formatter(func):
     def wrapper(data):
         

--- a/tests/api/test_utils_data_formatter.py
+++ b/tests/api/test_utils_data_formatter.py
@@ -1,0 +1,54 @@
+import json
+
+import pandas as pd
+
+from redcaplite.api.utils import data_formatter
+
+
+@data_formatter
+def _build_payload(data):
+    return {
+        'content': 'test',
+    }
+
+
+@data_formatter
+def _build_payload_with_format(data):
+    return {
+        'content': 'test',
+        'format': 'xml',
+    }
+
+
+def test_data_formatter_serializes_non_string_payload_to_json():
+    payload = {'data': [{'record_id': 1}]}
+
+    result = _build_payload(payload)
+
+    assert result == {
+        'content': 'test',
+        'format': 'json',
+        'data': json.dumps(payload['data']),
+    }
+
+
+def test_data_formatter_serializes_dataframe_payload_to_csv():
+    payload = {'data': pd.DataFrame([{'record_id': 1}, {'record_id': 2}])}
+
+    result = _build_payload(payload)
+
+    assert result['content'] == 'test'
+    assert result['format'] == 'csv'
+    assert result['data'] == 'record_id\n1\n2\n'
+
+
+def test_data_formatter_preserves_existing_format_for_string_payload():
+    payload = {'data': '<project></project>'}
+
+    result = _build_payload_with_format(payload)
+
+    assert result == {
+        'content': 'test',
+        'format': 'xml',
+        'data': '<project></project>',
+    }


### PR DESCRIPTION
### Motivation
- Consolidate API payload formatting by using a single shared decorator and remove a legacy duplicate implementation.
- Ensure consistent decorator naming and behavior across API modules that build request payloads.

### Description
- Replaced `json_data_formatter` imports and decorator usages with `data_formatter` in API modules `redcaplite/api/arm.py`, `redcaplite/api/event.py`, `redcaplite/api/form_event_mapping.py`, `redcaplite/api/project.py`, `redcaplite/api/repeating_forms_events.py`, `redcaplite/api/user.py`, `redcaplite/api/user_dag_mapping.py`, `redcaplite/api/user_role.py`, and `redcaplite/api/user_role_mapping.py` (see modified files: `redcaplite/api/*.py`).
- Removed the legacy duplicate `json_data_formatter` implementation from `redcaplite/api/utils.py` so a single `data_formatter` implementation is used (`redcaplite/api/utils.py`).
- Added an `[Unreleased]` changelog entry documenting the rename in `CHANGELOG.md`.

### Testing
- Ran the full test suite with `pytest` and all tests passed with `219 passed, 21 skipped` successfully. (See `pytest` output summary.)
- Verified affected modules import and use `data_formatter` and the project continues to pass automated tests (`redcaplite/api/*.py`, `redcaplite/api/utils.py`, `CHANGELOG.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de76a63d6c83308e8f028df536f670)