### PR TITLE
Apply data_formatter to metadata and record imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 ## [Unreleased]
 
 ### Changed
+- Applied the shared `data_formatter` decorator to metadata and record import API payload builders, removing duplicated manual CSV/JSON serialization logic.
 - Renamed shared API JSON formatting decorator references from `json_data_formatter` to `data_formatter` across API modules.
 - Added unit tests for `data_formatter` JSON/CSV/string formatting behavior to guard decorator regressions.
 - Simplified shared `data_formatter` fallback behavior to rely on `result['format']` defaults (typically set via `@optional_field`) before defaulting to JSON.

--- a/redcaplite/api/metadata.py
+++ b/redcaplite/api/metadata.py
@@ -1,6 +1,4 @@
-import json
-import pandas as pd
-from .utils import field_to_index, optional_field
+from .utils import data_formatter, field_to_index, optional_field
 
 
 @optional_field('format', 'csv')
@@ -13,15 +11,9 @@ def get_metadata(data):
     return (new_data)
 
 
+@data_formatter
 def import_metadata(data):
     new_data = {
         'content': 'metadata',
-        'format': data['format'],
     }
-    if data['format'] == 'csv' and isinstance(data['data'], pd.DataFrame):
-        new_data['data'] = data['data'].to_csv(index=False)
-    elif data['format'] == 'json':
-        new_data['data'] = json.dumps(data['data'])
-    else:
-        new_data['data'] = data['data']
     return (new_data)

--- a/redcaplite/api/record.py
+++ b/redcaplite/api/record.py
@@ -1,6 +1,4 @@
-import pandas as pd
-import json
-from .utils import field_to_index, optional_field, require_field
+from .utils import data_formatter, field_to_index, optional_field, require_field
 
 
 @optional_field('format', 'csv')
@@ -28,6 +26,7 @@ def export_records(data):
     return (new_data)
 
 
+@data_formatter
 @optional_field('overwriteBehavior', 'normal')
 @optional_field('forceAutoNumber', 'false')
 @optional_field('backgroundProcess')
@@ -38,15 +37,8 @@ def import_records(data):
     new_data = {
         'content': 'record',
         'action': 'import',
-        'format': data['format'],
         'type': 'flat',
     }
-    if data['format'] == 'csv' and isinstance(data['data'], pd.DataFrame):
-        new_data['data'] = data['data'].to_csv(index=False)
-    elif data['format'] == 'json':
-        new_data['data'] = json.dumps(data['data'])
-    else:
-        new_data['data'] = data['data']
     return (new_data)
 
 


### PR DESCRIPTION
### Motivation
- Centralize CSV/JSON payload serialization for imports so metadata and record import builders share the same formatting behavior used across the API. (`redcaplite/api/utils.py`).
- Remove duplicated inline serialization logic to reduce maintenance surface and keep import payload handling consistent with other API endpoints.

### Description
- Applied the shared `@data_formatter` decorator to `import_metadata` in `redcaplite/api/metadata.py` to delegate payload serialization to the shared utility (see `redcaplite/api/metadata.py`).
- Applied the shared `@data_formatter` decorator to `import_records` in `redcaplite/api/record.py` and removed the duplicated CSV/JSON serialization branches there (see `redcaplite/api/record.py`).
- Documented the change under the `## [Unreleased]` section in `CHANGELOG.md` (see `CHANGELOG.md`).

### Testing
- Ran `pytest` and all tests passed with the suite reporting `222 passed, 21 skipped` (see test run output in `artifacts/pytest.log`).
- Unit tests covering the formatter behavior, including `tests/api/test_utils_data_formatter.py`, passed as part of the test run (see `artifacts/pytest.log`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de78b166e48330a9b50e00ac808df9)