### PR TITLE
Release version 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 
 ## [Unreleased]
 
+## [2.2.2]
+
 ### Changed
 - Updated `data_formatter` to only auto-JSON serialize dict/list payloads when no non-JSON format is explicitly requested, preserving custom payload types (for example, bytes) for caller-selected formats.
 - Applied the shared `data_formatter` decorator to metadata and record import API payload builders, removing duplicated manual CSV/JSON serialization logic.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 `redcaplite` helps you connect to REDCap projects and perform common API and CLI workflows from one package. Whether you're a researcher automating data pulls or a developer building integrations, `redcaplite` supports both scripted API usage and command-line operations.
 
-## ✨ v2.2.1 – Safer metadata sync workflow
+## ✨ v2.2.2 – Metadata formatting and CLI help refinements
 
-Version 2.2.1 adds a safer metadata sync workflow with dry-run previews, clearer identity diagnostics, backup export support, and summary output while keeping the command-first style (`rcl <command> <profile> ...`).
+Version 2.2.2 improves shared API payload formatting behavior, expands CLI help text and examples, and refines sync display formatting while keeping the command-first style (`rcl <command> <profile> ...`).
 
 The CLI provides:
 - Profile-based access (`rcl <command> <profile> ...`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcaplite"
-version = "2.2.1"
+version = "2.2.2"
 authors = [
   { name="Jubilee Tan", email="jubilee2@gmail.com" },
 ]


### PR DESCRIPTION
### Motivation
- Prepare and publish a new patch release by bumping the package version and finalizing release notes so downstream consumers and the project README reflect the new `2.2.2` release (`pyproject.toml`, `CHANGELOG.md`, `README.md`).

### Description
- Bumped the package version from `2.2.1` to `2.2.2` in `pyproject.toml` (updated `version = "2.2.2"`).
- Promoted the prior `[Unreleased]` changelog entries into a new `## [2.2.2]` section and left an empty `## [Unreleased]` header in `CHANGELOG.md` to record the release history for `2.2.2` (`CHANGELOG.md`).
- Updated the README release highlight and summary to reference `v2.2.2` and describe the release focus (`README.md`).

### Testing
- Ran `pytest` in the project root and all automated tests passed with `223 passed, 21 skipped` (exit code 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de7ec63ba483309f63fa70db4aeb82)