### PR TITLE
Add DAG comparison and deterministic DAG import to `rcl sync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 ## [Unreleased]
 
 ### Changed
+- Simplified `rcl sync` DAG compare/import flow with explicit comparison table column constants and deterministic DAG import ordering for safer repeatable sync runs.
 - Replaced hard-coded API payload values of `'format': 'json'` with the shared `@optional_field('format', "json")` decorator across GET API request builders for consistent default handling.
 - Updated `data_formatter` to only auto-JSON serialize dict/list payloads when no non-JSON format is explicitly requested, preserving custom payload types (for example, bytes) for caller-selected formats.
 - Applied the shared `data_formatter` decorator to metadata and record import API payload builders, removing duplicated manual CSV/JSON serialization logic.

--- a/redcaplite/cli/sync.py
+++ b/redcaplite/cli/sync.py
@@ -15,6 +15,11 @@ from .helpers import ClientBootstrapError, build_client
 from .output import print_error, print_preview, print_success, print_table
 from .prompts import confirm
 
+_METADATA_DISPLAY_COLUMNS = ["field_name", "form_name", "field_type"]
+_DAG_DISPLAY_COLUMNS = ["unique_group_name", "data_access_group_name"]
+_DAG_COLUMNS = ["data_access_group_name", "unique_group_name"]
+
+
 def register_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Attach the ``sync`` command parser to the CLI root."""
     parser = subparsers.add_parser(
@@ -73,14 +78,20 @@ def run_sync(
         target_client = build_client(target_profile)
         source_metadata = source_client.get_metadata(format="csv")
         target_metadata = target_client.get_metadata(format="csv")
+        source_dags = _normalize_dag_frame(source_client.get_dags(format="csv"))
+        target_dags = _normalize_dag_frame(target_client.get_dags(format="csv"))
     except ClientBootstrapError as exc:
         print_error(str(exc))
         return 1
 
-    comparison = compare_metadata(source_metadata, target_metadata)
-    updates = comparison["updates"]
-    adds = comparison["adds"]
-    removals = comparison["removals"]
+    metadata_comparison = compare_metadata(source_metadata, target_metadata)
+    metadata_updates = metadata_comparison["updates"]
+    metadata_adds = metadata_comparison["adds"]
+    metadata_removals = metadata_comparison["removals"]
+
+    dag_comparison = compare_dags(source_dags, target_dags)
+    dag_adds = dag_comparison["adds"]
+    dag_removals = dag_comparison["removals"]
 
     print_preview(
         [
@@ -88,37 +99,57 @@ def run_sync(
             f'Source fields: {len(source_metadata.index)}',
             f'Target fields: {len(target_metadata.index)}',
             'Comparison derives adds/removals from all-column anti joins and detects updates for matching field_name values.',
-            f"Adds: {len(adds.index)}",
-            f"Updates: {len(updates.index)}",
-            f"Removals: {len(removals.index)}",
+            f"Adds: {len(metadata_adds.index)}",
+            f"Updates: {len(metadata_updates.index)}",
+            f"Removals: {len(metadata_removals.index)}",
         ]
     )
     _print_comparison_table(
         "Fields to add in target:",
-        metadata_to_records(adds),
-        columns=["field_name", "form_name", "field_type"],
+        metadata_to_records(metadata_adds),
+        columns=_METADATA_DISPLAY_COLUMNS,
     )
     _print_comparison_table(
         "Fields to update in target:",
-        metadata_to_records(updates),
-        columns=["field_name", "form_name", "field_type"],
+        metadata_to_records(metadata_updates),
+        columns=_METADATA_DISPLAY_COLUMNS,
     )
     _print_comparison_table(
         "Fields to remove from target:",
-        metadata_to_records(removals),
-        columns=["field_name", "form_name", "field_type"],
+        metadata_to_records(metadata_removals),
+        columns=_METADATA_DISPLAY_COLUMNS,
     )
 
-    if adds.empty and updates.empty and removals.empty:
-        print_success(f'No metadata differences found between "{source_profile}" and "{target_profile}".')
+    print_preview(
+        [
+            "Data Access Group comparison:",
+            f'Source DAGs: {len(source_dags.index)}',
+            f'Target DAGs: {len(target_dags.index)}',
+            f"DAGs to add: {len(dag_adds.index)}",
+            f"DAGs to remove: {len(dag_removals.index)}",
+        ]
+    )
+    _print_comparison_table(
+        "DAGs to add in target:",
+        _frame_to_records(dag_adds),
+        columns=_DAG_DISPLAY_COLUMNS,
+    )
+    _print_comparison_table(
+        "DAGs to remove from target:",
+        _frame_to_records(dag_removals),
+        columns=_DAG_DISPLAY_COLUMNS,
+    )
+
+    if _has_no_differences(metadata_comparison, dag_comparison):
+        print_success(f'No metadata or DAG differences found between "{source_profile}" and "{target_profile}".')
         return 0
 
     if dry_run:
-        print_success("Dry run enabled; no metadata was imported.")
+        print_success("Dry run enabled; no metadata or DAGs were imported.")
         return 0
 
     if not assume_yes and not confirm(
-        f'Import metadata from "{source_profile}" into "{target_profile}"? [y/N]: '
+        f'Import metadata and DAGs from "{source_profile}" into "{target_profile}"? [y/N]: '
     ):
         print_error("cancelled by user.")
         return 1
@@ -129,7 +160,10 @@ def run_sync(
         print_success(f'Exported target metadata backup to "{backup_path}".')
 
     target_client.import_metadata(source_metadata, format="csv")
-    print_success(f'Imported metadata from "{source_profile}" into "{target_profile}".')
+    dag_import_payload = _deterministic_dag_records(source_dags)
+    if dag_import_payload:
+        target_client.import_dags(dag_import_payload)
+    print_success(f'Imported metadata and DAGs from "{source_profile}" into "{target_profile}".')
     return 0
 
 
@@ -147,6 +181,16 @@ def compare_metadata(
     return {
         "adds": source_only,
         "updates": updates,
+        "removals": target_only,
+    }
+
+
+def compare_dags(source_dags: pd.DataFrame, target_dags: pd.DataFrame) -> dict[str, pd.DataFrame]:
+    """Return DAG differences as additions and removals."""
+    source_only = _left_anti_rows(source_dags, target_dags)
+    target_only = _left_anti_rows(target_dags, source_dags)
+    return {
+        "adds": source_only,
         "removals": target_only,
     }
 
@@ -177,7 +221,7 @@ def _left_anti_rows(
     return left_frame.merge(
         right_frame.drop_duplicates(),
         how="left_anti",
-        on=columns
+        on=columns,
     )
 
 
@@ -188,6 +232,51 @@ def _normalize_backup_file_path(backup_file: str) -> Path:
         timestamp = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
         return backup_path / f"target_metadata_backup_{timestamp}.csv"
     return backup_path
+
+
+def _normalize_dag_frame(raw_dags: Any) -> pd.DataFrame:
+    """Convert DAG API responses to a normalized DataFrame with expected columns."""
+    if isinstance(raw_dags, pd.DataFrame):
+        frame = raw_dags.copy()
+    else:
+        frame = pd.DataFrame(raw_dags)
+    if frame.empty:
+        return pd.DataFrame(columns=_DAG_COLUMNS)
+    for column in _DAG_COLUMNS:
+        if column not in frame.columns:
+            frame[column] = ""
+    return frame[_DAG_COLUMNS].fillna("")
+
+
+def _deterministic_dag_records(dags: pd.DataFrame) -> list[dict[str, str]]:
+    """Return DAG records in a stable order for safe import payloads."""
+    normalized = _normalize_dag_frame(dags)
+    if normalized.empty:
+        return []
+    sorted_dags = normalized.drop_duplicates().sort_values(by=["unique_group_name", "data_access_group_name"])
+    return _frame_to_records(sorted_dags)
+
+
+def _has_no_differences(
+    metadata_comparison: dict[str, pd.DataFrame],
+    dag_comparison: dict[str, pd.DataFrame],
+) -> bool:
+    """Return True when metadata and DAG comparisons are both empty."""
+    return (
+        metadata_comparison["adds"].empty
+        and metadata_comparison["updates"].empty
+        and metadata_comparison["removals"].empty
+        and dag_comparison["adds"].empty
+        and dag_comparison["removals"].empty
+    )
+
+
+def _frame_to_records(rows: pd.DataFrame) -> list[dict[str, str]]:
+    """Convert arbitrary DataFrame rows to serializable dict records."""
+    if rows.empty:
+        return []
+    return rows.to_dict(orient="records")
+
 
 def _print_comparison_table(
     title: str,

--- a/redcaplite/redcap.py
+++ b/redcaplite/redcap.py
@@ -65,17 +65,22 @@ class RedcapClient(Client):
         return self.post(api.delete_arms({"arms": arms}))
 
     # dags
-    def get_dags(self, output_file: Optional[str] = None):
+    def get_dags(
+        self,
+        format: Literal["csv", "json"] = "json",
+        output_file: Optional[str] = None,
+    ):
         """
         Get all Data Access Groups (DAGs) for the project.
 
         Args:
+            format (Literal["csv", "json"]): Response format.
             output_file (Optional[str]): Path to save the raw API response.
 
         Returns:
             The response from the API containing DAG information.
         """
-        return self.post(api.get_dags({}), output_file=output_file)
+        return self.post(api.get_dags({"format": format}), output_file=output_file)
 
     def import_dags(self, data: RedcapDataType):
         """

--- a/tests/cli/fakes.py
+++ b/tests/cli/fakes.py
@@ -17,6 +17,7 @@ class MetadataClient(FakeClient):
         super().__init__(url, token)
         self.imported_metadata: pd.DataFrame | None = None
         self.imported_format: str | None = None
+        self.imported_dags: list[dict[str, str]] | None = None
         self.exported_metadata_output_file: str | None = None
         self._metadata = [
             {
@@ -58,11 +59,30 @@ class MetadataClient(FakeClient):
         self.imported_format = format
         return "1"
 
+    def get_dags(self, format: str = "csv") -> list[dict[str, str]]:
+        assert format == "csv"
+        return []
+
+    def import_dags(self, data: list[dict[str, str]]) -> str:
+        self.imported_dags = data
+        return "1"
+
 
 class SyncMetadataClient(MetadataClient):
-    def __init__(self, url: str, token: str, metadata: list[dict[str, str]]) -> None:
+    def __init__(
+        self,
+        url: str,
+        token: str,
+        metadata: list[dict[str, str]],
+        dags: list[dict[str, str]] | None = None,
+    ) -> None:
         super().__init__(url, token)
         self._metadata = metadata
+        self._dags = dags or []
+
+    def get_dags(self, format: str = "csv") -> list[dict[str, str]]:
+        assert format == "csv"
+        return self._dags
 
 
 class FailingClient(FakeClient):

--- a/tests/cli/test_sync.py
+++ b/tests/cli/test_sync.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from redcaplite.cli.sync import compare_metadata
-from redcaplite.metadata_ops.transform import metadata_to_records
+from redcaplite.cli.sync import compare_dags, compare_metadata
 from redcaplite.cli.main import main
 from tests.cli.fakes import SyncMetadataClient
 
@@ -35,6 +34,10 @@ def test_main_sync_prints_differences_and_imports_source_metadata(monkeypatch, c
                 "required_field": "",
             },
         ],
+        dags=[
+            {"unique_group_name": "site_b", "data_access_group_name": "Site B"},
+            {"unique_group_name": "site_a", "data_access_group_name": "Site A"},
+        ],
     )
     target_client = SyncMetadataClient(
         "https://target.example.edu/api/",
@@ -62,6 +65,10 @@ def test_main_sync_prints_differences_and_imports_source_metadata(monkeypatch, c
                 "required_field": "",
             },
         ],
+        dags=[
+            {"unique_group_name": "site_b", "data_access_group_name": "Site B"},
+            {"unique_group_name": "legacy_site", "data_access_group_name": "Legacy Site"},
+        ],
     )
     monkeypatch.setattr(
         "redcaplite.cli.sync.build_client",
@@ -82,11 +89,19 @@ def test_main_sync_prints_differences_and_imports_source_metadata(monkeypatch, c
     assert "field_name" in captured.out
     assert "form_name" in captured.out
     assert "field_type" in captured.out
+    assert "DAGs to add in target:" in captured.out
+    assert "DAGs to remove from target:" in captured.out
+    assert "site_a" in captured.out
+    assert "legacy_site" in captured.out
     assert "field_label" not in captured.out
     assert "Weight" not in captured.out
-    assert 'Imported metadata from "profile1" into "profile2".' in captured.out
+    assert 'Imported metadata and DAGs from "profile1" into "profile2".' in captured.out
     assert target_client.imported_metadata is not None
     assert list(target_client.imported_metadata["field_name"]) == ["record_id", "age", "height"]
+    assert target_client.imported_dags == [
+        {"data_access_group_name": "Site A", "unique_group_name": "site_a"},
+        {"data_access_group_name": "Site B", "unique_group_name": "site_b"},
+    ]
     assert captured.err == ""
 
 
@@ -147,8 +162,9 @@ def test_main_sync_reports_when_metadata_matches(monkeypatch, capsys) -> None:
     assert main(["sync", "profile1", "profile2"]) == 0
 
     captured = capsys.readouterr()
-    assert 'No metadata differences found between "profile1" and "profile2".' in captured.out
+    assert 'No metadata or DAG differences found between "profile1" and "profile2".' in captured.out
     assert target_client.imported_metadata is None
+    assert target_client.imported_dags is None
     assert captured.err == ""
 
 
@@ -239,8 +255,9 @@ def test_main_sync_dry_run_never_imports(monkeypatch, capsys) -> None:
     assert main(["sync", "profile1", "profile2", "--dry-run", "--yes"]) == 0
 
     captured = capsys.readouterr()
-    assert "Dry run enabled; no metadata was imported." in captured.out
+    assert "Dry run enabled; no metadata or DAGs were imported." in captured.out
     assert target_client.imported_metadata is None
+    assert target_client.imported_dags is None
 
 
 def test_main_sync_prints_summary_counts(monkeypatch, capsys) -> None:
@@ -272,6 +289,8 @@ def test_main_sync_prints_summary_counts(monkeypatch, capsys) -> None:
     assert "Updates: 1" in captured.out
     assert "Removals: 0" in captured.out
     assert "Fields to update in target:" in captured.out
+    assert "DAGs to add: 0" in captured.out
+    assert "DAGs to remove: 0" in captured.out
 
 
 def test_main_sync_exports_backup_before_import(monkeypatch, capsys, tmp_path) -> None:
@@ -297,3 +316,27 @@ def test_main_sync_exports_backup_before_import(monkeypatch, capsys, tmp_path) -
     assert "Exported target metadata backup" in captured.out
     assert target_client.exported_metadata_output_file == str(backup_file)
     assert target_client.imported_metadata is not None
+
+
+def test_compare_dags_reports_adds_and_removals() -> None:
+    source_dags = pd.DataFrame(
+        [
+            {"unique_group_name": "site_a", "data_access_group_name": "Site A"},
+            {"unique_group_name": "site_b", "data_access_group_name": "Site B"},
+        ]
+    )
+    target_dags = pd.DataFrame(
+        [
+            {"unique_group_name": "site_a", "data_access_group_name": "Site A"},
+            {"unique_group_name": "legacy_site", "data_access_group_name": "Legacy Site"},
+        ]
+    )
+
+    comparison = compare_dags(source_dags, target_dags)
+
+    assert comparison["adds"].to_dict(orient="records") == [
+        {"unique_group_name": "site_b", "data_access_group_name": "Site B"}
+    ]
+    assert comparison["removals"].to_dict(orient="records") == [
+        {"unique_group_name": "legacy_site", "data_access_group_name": "Legacy Site"}
+    ]


### PR DESCRIPTION
### Motivation
- Extend `rcl sync` to compare and optionally import Data Access Groups (DAGs) in addition to metadata for safer project syncs.
- Ensure DAG import payloads are deterministic and repeatable by applying a stable sort and explicit column ordering.
- Standardize displayed comparison columns and help text so CLI output and usage are clearer and consistent.

### Description
- Added DAG display/column constants `_DAG_DISPLAY_COLUMNS`, `_DAG_COLUMNS`, and metadata display columns `_METADATA_DISPLAY_COLUMNS` in `redcaplite/cli/sync.py` and used them for table output.
- Introduced `_normalize_dag_frame`, `compare_dags`, `_deterministic_dag_records`, `_frame_to_records`, and `_has_no_differences` helpers in `redcaplite/cli/sync.py` to normalize DAG API responses, compute adds/removals, produce deterministic import payloads, and compose combined emptiness checks.
- Updated `run_sync` flow to fetch DAGs from both source and target, print DAG comparison summaries, and import DAGs via a deterministic payload when performing the import action.
- Modified `redcaplite/redcap.py` `get_dags` method to accept a `format` parameter and forward it in the API call.
- Updated test fakes and unit tests in `tests/cli/fakes.py` and `tests/cli/test_sync.py` to simulate DAG responses, validate printed DAG sections, assert deterministic DAG import ordering, and added `test_compare_dags_reports_adds_and_removals`.

### Testing
- Ran the CLI sync unit tests in `tests/cli/test_sync.py`, including the new `test_compare_dags_reports_adds_and_removals`, and they passed.
- Validated that `main(["sync", ...])` scenarios exercise the new DAG code path and assertions for import payload and output messages succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de881569308330b9219f0bae1ba548)