### PR TITLE
Release v2.2.3 — bump version and roll changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 ## [Unreleased]
 
 ### Changed
+- No changes yet.
+
+## [2.2.3]
+
+### Changed
 - Updated `RedcapClient` JSON-default export helpers (arms, DAGs, user-DAG mappings, events, field names, instruments, form-event mappings, project, repeating forms/events, users, user roles, and user-role mappings) to explicitly expose `format: Literal["json", "csv"] = "json"` and forward it in request payloads, aligning client method defaults with API `@optional_field('format', "json")` behavior.
 
 ## [2.2.2]

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 `redcaplite` helps you connect to REDCap projects and perform common API and CLI workflows from one package. Whether you're a researcher automating data pulls or a developer building integrations, `redcaplite` supports both scripted API usage and command-line operations.
 
-## ✨ v2.2.2 – Metadata formatting and CLI help refinements
+## ✨ v2.2.3 – JSON-default export helper alignment
 
-Version 2.2.2 improves shared API payload formatting behavior, expands CLI help text and examples, and refines sync display formatting while keeping the command-first style (`rcl <command> <profile> ...`).
+Version 2.2.3 aligns `RedcapClient` JSON-default export helper signatures with API format defaults by explicitly exposing and forwarding `format` options while preserving the command-first CLI style (`rcl <command> <profile> ...`).
 
 The CLI provides:
 - Profile-based access (`rcl <command> <profile> ...`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcaplite"
-version = "2.2.2"
+version = "2.2.3"
 authors = [
   { name="Jubilee Tan", email="jubilee2@gmail.com" },
 ]


### PR DESCRIPTION
### Motivation
- Prepare a new patch release `2.2.3` by advancing package metadata and recording prior Unreleased changes under the new release heading.

### Description
- Updated the package version in `pyproject.toml` to `2.2.3`.
- Rolled the existing `## [Unreleased]` changes into a new `## [2.2.3]` section and added a fresh `## [Unreleased]` placeholder in `CHANGELOG.md`.
- Updated the README release highlight to `v2.2.3` and adjusted the short release summary in `README.md`.

### Testing
- Ran the test suite with `pytest`, which completed successfully with `223 passed, 21 skipped` (see `.pytest.log`).
- All repository unit and integration tests exercised in CI-local run passed as reported by `pytest`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de954b26288330b2a9e6a6b982b568)