### PR TITLE
Handle empty CSV responses with endpoint-aware schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 ## [Unreleased]
 
 ### Changed
+- Simplified `Client.post(...)` CSV forwarding further by always passing `empty_columns` (including `None`) directly to `__csv_api`, reducing branching with no behavior change.
 - Added optional CSV empty-schema support in the HTTP client/handler pipeline via `empty_columns`, so blank CSV responses can return a zero-row DataFrame with known columns when provided.
 - Added a centralized REDCap CSV schema registry and wired fixed-schema export endpoints to pass their empty-column definitions while leaving dynamic exports on the previous empty DataFrame fallback.
 - Added regression tests for blank CSV handling with and without schema columns, CSV schema forwarding through the client, and `RedcapClient` endpoint wiring for empty-column metadata.
-- Simplified CSV request forwarding in `Client.post(...)` to remove an unnecessary intermediate kwargs dictionary while keeping the `empty_columns` pass-through behavior unchanged.
 
 ## [2.2.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 ## [Unreleased]
 
 ### Changed
-- No changes yet.
+- Added optional CSV empty-schema support in the HTTP client/handler pipeline via `empty_columns`, so blank CSV responses can return a zero-row DataFrame with known columns when provided.
+- Added a centralized REDCap CSV schema registry and wired fixed-schema export endpoints to pass their empty-column definitions while leaving dynamic exports on the previous empty DataFrame fallback.
+- Added regression tests for blank CSV handling with and without schema columns, CSV schema forwarding through the client, and `RedcapClient` endpoint wiring for empty-column metadata.
 
 ## [2.2.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 - Added optional CSV empty-schema support in the HTTP client/handler pipeline via `empty_columns`, so blank CSV responses can return a zero-row DataFrame with known columns when provided.
 - Added a centralized REDCap CSV schema registry and wired fixed-schema export endpoints to pass their empty-column definitions while leaving dynamic exports on the previous empty DataFrame fallback.
 - Added regression tests for blank CSV handling with and without schema columns, CSV schema forwarding through the client, and `RedcapClient` endpoint wiring for empty-column metadata.
+- Simplified CSV request forwarding in `Client.post(...)` to remove an unnecessary intermediate kwargs dictionary while keeping the `empty_columns` pass-through behavior unchanged.
 
 ## [2.2.3]
 

--- a/redcaplite/api/schemas.py
+++ b/redcaplite/api/schemas.py
@@ -1,0 +1,17 @@
+from typing import Dict, List
+
+
+CSV_EMPTY_SCHEMAS: Dict[str, List[str]] = {
+    "get_arms": ["arm_num", "name"],
+    "get_dags": ["data_access_group_name", "unique_group_name"],
+    "get_user_dag_mappings": ["username", "redcap_data_access_group"],
+    "get_events": ["event_name", "arm_num", "unique_event_name"],
+    "get_field_names": ["original_field_name", "export_field_name"],
+    "get_instruments": ["instrument_name", "instrument_label"],
+    "get_form_event_mappings": ["arm_num", "unique_event_name", "form"],
+    "get_repeating_forms_events": ["event_name", "form_name", "custom_form_label"],
+}
+
+
+def get_empty_csv_columns(endpoint_name: str) -> List[str]:
+    return list(CSV_EMPTY_SCHEMAS.get(endpoint_name, []))

--- a/redcaplite/http/client.py
+++ b/redcaplite/http/client.py
@@ -20,16 +20,19 @@ class Client:
             pd_read_csv_kwargs = {}
         format = data.get("format", None)
         if format == 'csv':
-            csv_kwargs = {
-                "pd_read_csv_kwargs": pd_read_csv_kwargs,
-                "output_file": output_file,
-            }
-            if empty_columns is not None:
-                csv_kwargs["empty_columns"] = empty_columns
-            response = self.__csv_api(
-                data,
-                **csv_kwargs,
-            )
+            if empty_columns is None:
+                response = self.__csv_api(
+                    data,
+                    pd_read_csv_kwargs=pd_read_csv_kwargs,
+                    output_file=output_file,
+                )
+            else:
+                response = self.__csv_api(
+                    data,
+                    pd_read_csv_kwargs=pd_read_csv_kwargs,
+                    output_file=output_file,
+                    empty_columns=empty_columns,
+                )
         elif format == 'json':
             response = self.__json_api(data, output_file=output_file)
         elif format == 'xml':

--- a/redcaplite/http/client.py
+++ b/redcaplite/http/client.py
@@ -1,3 +1,5 @@
+from typing import Optional, Sequence
+
 import requests
 import redcaplite.http.handler as hd
 
@@ -7,15 +9,26 @@ class Client:
         self.url = url
         self.token = token
 
-    def post(self, data, pd_read_csv_kwargs=None, output_file=None):
+    def post(
+        self,
+        data,
+        pd_read_csv_kwargs=None,
+        output_file=None,
+        empty_columns: Optional[Sequence[str]] = None,
+    ):
         if pd_read_csv_kwargs is None:
             pd_read_csv_kwargs = {}
         format = data.get("format", None)
         if format == 'csv':
+            csv_kwargs = {
+                "pd_read_csv_kwargs": pd_read_csv_kwargs,
+                "output_file": output_file,
+            }
+            if empty_columns is not None:
+                csv_kwargs["empty_columns"] = empty_columns
             response = self.__csv_api(
                 data,
-                pd_read_csv_kwargs=pd_read_csv_kwargs,
-                output_file=output_file,
+                **csv_kwargs,
             )
         elif format == 'json':
             response = self.__json_api(data, output_file=output_file)

--- a/redcaplite/http/client.py
+++ b/redcaplite/http/client.py
@@ -20,19 +20,12 @@ class Client:
             pd_read_csv_kwargs = {}
         format = data.get("format", None)
         if format == 'csv':
-            if empty_columns is None:
-                response = self.__csv_api(
-                    data,
-                    pd_read_csv_kwargs=pd_read_csv_kwargs,
-                    output_file=output_file,
-                )
-            else:
-                response = self.__csv_api(
-                    data,
-                    pd_read_csv_kwargs=pd_read_csv_kwargs,
-                    output_file=output_file,
-                    empty_columns=empty_columns,
-                )
+            response = self.__csv_api(
+                data,
+                pd_read_csv_kwargs=pd_read_csv_kwargs,
+                output_file=output_file,
+                empty_columns=empty_columns,
+            )
         elif format == 'json':
             response = self.__json_api(data, output_file=output_file)
         elif format == 'xml':

--- a/redcaplite/http/client.py
+++ b/redcaplite/http/client.py
@@ -18,17 +18,17 @@ class Client:
     ):
         if pd_read_csv_kwargs is None:
             pd_read_csv_kwargs = {}
-        format = data.get("format", None)
-        if format == 'csv':
+        fmt = data.get("format", None)
+        if fmt == 'csv':
             response = self.__csv_api(
                 data,
                 pd_read_csv_kwargs=pd_read_csv_kwargs,
                 output_file=output_file,
                 empty_columns=empty_columns,
             )
-        elif format == 'json':
+        elif fmt == 'json':
             response = self.__json_api(data, output_file=output_file)
-        elif format == 'xml':
+        elif fmt == 'xml':
             response = self.text_api(data, output_file=output_file)
         else:
             response = self.text_api(data, output_file=output_file)

--- a/redcaplite/http/handler.py
+++ b/redcaplite/http/handler.py
@@ -3,7 +3,7 @@ import os
 import io
 import pandas as pd
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Sequence, Union
 
 
 def output_handler(func):
@@ -57,7 +57,13 @@ def response_error_handler(func):
 
 
 def csv_handler(func):
-    def wrapper(obj, data, pd_read_csv_kwargs=None, output_file=None):
+    def wrapper(
+        obj,
+        data,
+        pd_read_csv_kwargs=None,
+        output_file=None,
+        empty_columns: Optional[Sequence[str]] = None,
+    ):
         if pd_read_csv_kwargs is None:
             pd_read_csv_kwargs = {}
         data['format'] = 'csv'
@@ -65,7 +71,9 @@ def csv_handler(func):
         if 'returnContent' in data and data['returnContent'] == 'ids':
             return response.json()
         if response.text.strip() == '':
-            return pd.DataFrame()  # Return an empty DataFrame if response is empty
+            if empty_columns:
+                return pd.DataFrame(columns=list(empty_columns))
+            return pd.DataFrame()
         io_string = io.StringIO(response.text)
         df = pd.read_csv(io_string, **pd_read_csv_kwargs)
         io_string.close()

--- a/redcaplite/redcap.py
+++ b/redcaplite/redcap.py
@@ -1,4 +1,5 @@
 from redcaplite import api
+from redcaplite.api.schemas import get_empty_csv_columns
 from .http import Client
 from typing import List, Optional, Dict, Any, Union, Literal
 from datetime import datetime
@@ -44,6 +45,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_arms({"arms": arms, "format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_arms"),
         )
 
     def import_arms(
@@ -92,6 +94,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_dags({"format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_dags"),
         )
 
     def import_dags(self, data: RedcapDataType):
@@ -149,6 +152,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_user_dag_mappings({"format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_user_dag_mappings"),
         )
 
     def import_user_dag_mappings(self, data: RedcapDataType):
@@ -184,6 +188,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_events({"arms": arms, "format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_events"),
         )
 
     def import_events(self, data: RedcapDataType):
@@ -231,6 +236,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_field_names({"field": field, "format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_field_names"),
         )
 
     # file
@@ -436,6 +442,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_instruments({"format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_instruments"),
         )
 
     # pdf
@@ -499,6 +506,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_form_event_mappings({"arms": arms, "format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_form_event_mappings"),
         )
 
     def import_form_event_mappings(self, data: RedcapDataType):
@@ -935,6 +943,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_repeating_forms_events({"format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_repeating_forms_events"),
         )
 
     def import_repeating_forms_events(self, data: RedcapDataType):

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -27,20 +27,32 @@ def test_client_post_csv():
         response = client.post({'format': 'csv'})
         assert response == mock_response
         mock_csv_api.assert_called_once_with(
-            {'format': 'csv'}, pd_read_csv_kwargs={}, output_file=None)
+            {'format': 'csv'},
+            pd_read_csv_kwargs={},
+            output_file=None,
+            empty_columns=None,
+        )
 
     with patch.object(client, '_Client__csv_api', return_value=mock_response) as mock_csv_api:
         response = client.post(
             {'format': 'csv'}, pd_read_csv_kwargs={"foo": []})
         assert response == mock_response
         mock_csv_api.assert_called_once_with(
-            {'format': 'csv'}, pd_read_csv_kwargs={"foo": []}, output_file=None)
+            {'format': 'csv'},
+            pd_read_csv_kwargs={"foo": []},
+            output_file=None,
+            empty_columns=None,
+        )
 
     with patch.object(client, '_Client__csv_api', return_value=mock_response) as mock_csv_api:
         response = client.post({'format': 'csv'}, output_file='records.csv')
         assert response == mock_response
         mock_csv_api.assert_called_once_with(
-            {'format': 'csv'}, pd_read_csv_kwargs={}, output_file='records.csv')
+            {'format': 'csv'},
+            pd_read_csv_kwargs={},
+            output_file='records.csv',
+            empty_columns=None,
+        )
 
 
 def test_client_post_json_with_output_file():

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -111,3 +111,21 @@ def test_client_file_upload_api():
             response = client.file_upload_api('file.txt', {})
             assert response == mock_response
             mock_file.assert_called_once_with('file.txt', 'rb')
+
+
+def test_client_post_csv_with_empty_columns():
+    """Test Client post method forwards empty schema columns for CSV."""
+    client = Client('https://example.com', 'token')
+    mock_response = Mock()
+    with patch.object(client, '_Client__csv_api', return_value=mock_response) as mock_csv_api:
+        response = client.post(
+            {'format': 'csv'},
+            empty_columns=["arm_num", "name"],
+        )
+        assert response == mock_response
+        mock_csv_api.assert_called_once_with(
+            {'format': 'csv'},
+            pd_read_csv_kwargs={},
+            output_file=None,
+            empty_columns=["arm_num", "name"],
+        )

--- a/tests/http/test_handler.py
+++ b/tests/http/test_handler.py
@@ -123,6 +123,16 @@ def test_csv_handler_return_empty():
         response, pd.DataFrame())
 
 
+def test_csv_handler_return_empty_with_columns():
+    """Test csv_handler decorator returns schema-aware empty DataFrame."""
+    mock_func = Mock(return_value=Mock(text='\n'))
+    decorated_func = csv_handler(mock_func)
+    response = decorated_func(None, {}, empty_columns=["arm_num", "name"])
+    assert isinstance(response, pd.DataFrame)
+    pd.testing.assert_frame_equal(
+        response, pd.DataFrame(columns=["arm_num", "name"]))
+
+
 def test_csv_handler_csv_reader():
     """Test csv_handler decorator"""
     mock_func = Mock(return_value=Mock(text='csv data,date\n04,005'))

--- a/tests/test_redcap.py
+++ b/tests/test_redcap.py
@@ -91,6 +91,17 @@ def test_redcap_client_delete_arms(client):
     )
 
 
+def test_redcap_client_get_arms_forwards_empty_columns(client):
+    """Test get_arms forwards schema columns for empty CSV responses."""
+    with patch.object(client, 'post', return_value=Mock()) as mock_post:
+        client.get_arms(format='csv')
+        mock_post.assert_called_once_with(
+            {'content': 'arm', 'format': 'csv'},
+            output_file=None,
+            empty_columns=['arm_num', 'name'],
+        )
+
+
 # Dags
 def test_redcap_client_get_dags(client):
     """Test RedcapClient get_dags method"""


### PR DESCRIPTION
### Motivation
- Some REDCap CSV endpoints return an empty string (`""`) which previously became a generic `pd.DataFrame()` with no columns, losing schema information for fixed-schema CSV endpoints.  
- The goal is to preserve column structure for fixed-schema CSV endpoints while keeping dynamic exports schema-agnostic and preserving backward compatibility.  
- Responsibility should stay centralized in the CSV parsing layer while allowing endpoints to opt-in with known schemas.

### Description
- Added an optional `empty_columns` parameter to the CSV handler pipeline so blank CSV responses return `pd.DataFrame(columns=empty_columns)` when provided, else the existing empty-DataFrame fallback is used (`redcaplite/http/handler.py`).
- Extended `Client.post(...)` to accept `empty_columns: Optional[Sequence[str]]` and forward it only for CSV requests (`redcaplite/http/client.py`).
- Introduced a small centralized schema registry `redcaplite/api/schemas.py` with `get_empty_csv_columns(...)` to avoid scattering hard-coded column lists.  
- Wired fixed-schema endpoints to opt-in by passing `empty_columns=get_empty_csv_columns("<endpoint>")` in `RedcapClient` for arms, dags, user-DAG mappings, events, field names, instruments, form-event mappings, and repeating-forms/events while leaving dynamic endpoints unmodified (`redcaplite/redcap.py`).
- Added tests to validate blank-CSV behavior with and without provided columns and to ensure client forwarding and endpoint wiring (`tests/http/test_handler.py`, `tests/http/test_client.py`, `tests/test_redcap.py`).  
- Updated `CHANGELOG.md` under `[Unreleased]` to document the change.

### Testing
- Ran the full test-suite with `pytest` after changes; the run completed successfully with `226 passed, 21 skipped` (see test output).  
- New/updated unit tests executed include blank-CSV-with-columns (`tests/http/test_handler.py`), blank-CSV-without-columns fallback (`tests/http/test_handler.py`), client forwarding (`tests/http/test_client.py`), and endpoint wiring (`tests/test_redcap.py`), and all passed as part of the run.  

Files changed: `redcaplite/http/handler.py`, `redcaplite/http/client.py`, `redcaplite/redcap.py`, `redcaplite/api/schemas.py`, `tests/http/test_handler.py`, `tests/http/test_client.py`, `tests/test_redcap.py`, and `CHANGELOG.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dff30c06348330a24e14876d5d6d33)