### PR TITLE
Schema-aware empty CSV handling: propagate `empty_columns` through client, handler, and RedcapClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 ## [Unreleased]
 
 ### Changed
+- Expanded the centralized CSV empty-schema registry and endpoint wiring to include user roles and user-role mappings exports so blank CSV responses now return correctly structured zero-row DataFrames for those fixed-schema APIs.
 - Simplified blank CSV handling in `csv_handler` to rely on `pd.DataFrame(columns=empty_columns)`, which naturally preserves the legacy fallback for `None` and schema columns when provided.
 - Simplified `Client.post(...)` CSV forwarding further by always passing `empty_columns` (including `None`) directly to `__csv_api`, reducing branching with no behavior change.
 - Added optional CSV empty-schema support in the HTTP client/handler pipeline via `empty_columns`, so blank CSV responses can return a zero-row DataFrame with known columns when provided.
 - Added a centralized REDCap CSV schema registry and wired fixed-schema export endpoints to pass their empty-column definitions while leaving dynamic exports on the previous empty DataFrame fallback.
-- Added regression tests for blank CSV handling with and without schema columns, CSV schema forwarding through the client, and `RedcapClient` endpoint wiring for empty-column metadata.
+- Added regression tests for blank CSV handling with and without schema columns and `RedcapClient` endpoint wiring for empty-column forwarding.
 
 ## [2.2.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 ## [Unreleased]
 
 ### Changed
-- No changes yet.
+- Simplified blank CSV handling in `csv_handler` to rely on `pd.DataFrame(columns=empty_columns)`, which naturally preserves the legacy fallback for `None` and schema columns when provided.
+- Simplified `Client.post(...)` CSV forwarding further by always passing `empty_columns` (including `None`) directly to `__csv_api`, reducing branching with no behavior change.
+- Added optional CSV empty-schema support in the HTTP client/handler pipeline via `empty_columns`, so blank CSV responses can return a zero-row DataFrame with known columns when provided.
+- Added a centralized REDCap CSV schema registry and wired fixed-schema export endpoints to pass their empty-column definitions while leaving dynamic exports on the previous empty DataFrame fallback.
+- Added regression tests for blank CSV handling with and without schema columns, CSV schema forwarding through the client, and `RedcapClient` endpoint wiring for empty-column metadata.
 
 ## [2.2.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 ## [Unreleased]
 
 ### Changed
+- Aligned user-role CSV forwarding tests with the expanded fixed-schema column definitions used by the client for empty CSV responses.
+
+## [2.3.0]
+
+### Changed
 - Expanded the centralized CSV empty-schema registry and endpoint wiring to include user roles and user-role mappings exports so blank CSV responses now return correctly structured zero-row DataFrames for those fixed-schema APIs.
 - Simplified blank CSV handling in `csv_handler` to rely on `pd.DataFrame(columns=empty_columns)`, which naturally preserves the legacy fallback for `None` and schema columns when provided.
 - Simplified `Client.post(...)` CSV forwarding further by always passing `empty_columns` (including `None`) directly to `__csv_api`, reducing branching with no behavior change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog, with entries listed in reverse chronological order.
 
 ## [Unreleased]
+- No changes yet.
 
 
 ## [2.3.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,11 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 
 ## [Unreleased]
 
-### Changed
-- Aligned user-role CSV forwarding tests with the expanded fixed-schema column definitions used by the client for empty CSV responses.
 
 ## [2.3.0]
 
 ### Changed
+- Aligned user-role CSV forwarding tests with the expanded fixed-schema column definitions used by the client for empty CSV responses.
 - Expanded the centralized CSV empty-schema registry and endpoint wiring to include user roles and user-role mappings exports so blank CSV responses now return correctly structured zero-row DataFrames for those fixed-schema APIs.
 - Simplified blank CSV handling in `csv_handler` to rely on `pd.DataFrame(columns=empty_columns)`, which naturally preserves the legacy fallback for `None` and schema columns when provided.
 - Simplified `Client.post(...)` CSV forwarding further by always passing `empty_columns` (including `None`) directly to `__csv_api`, reducing branching with no behavior change.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 `redcaplite` helps you connect to REDCap projects and perform common API and CLI workflows from one package. Whether you're a researcher automating data pulls or a developer building integrations, `redcaplite` supports both scripted API usage and command-line operations.
 
-## ✨ v2.2.3 – JSON-default export helper alignment
+## ✨ v2.3.0 – CSV empty-schema support and handler simplification
 
-Version 2.2.3 aligns `RedcapClient` JSON-default export helper signatures with API format defaults by explicitly exposing and forwarding `format` options while preserving the command-first CLI style (`rcl <command> <profile> ...`).
+Version 2.3.0 expands empty CSV handling with endpoint-aware schema defaults, so fixed-schema exports now return zero-row DataFrames with expected columns while dynamic exports preserve legacy fallback behavior.
 
 The CLI provides:
 - Profile-based access (`rcl <command> <profile> ...`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcaplite"
-version = "2.2.3"
+version = "2.3.0"
 authors = [
   { name="Jubilee Tan", email="jubilee2@gmail.com" },
 ]

--- a/redcaplite/api/schemas.py
+++ b/redcaplite/api/schemas.py
@@ -3,10 +3,10 @@ from typing import Dict, List
 
 CSV_EMPTY_SCHEMAS: Dict[str, List[str]] = {
     "get_arms": ["arm_num", "name"],
-    "get_dags": ["data_access_group_name", "unique_group_name"],
+    "get_dags": ["data_access_group_name", "unique_group_name", "data_access_group_id"],
     "get_user_dag_mappings": ["username", "redcap_data_access_group"],
-    "get_events": ["event_name", "arm_num", "unique_event_name"],
-    "get_field_names": ["original_field_name", "export_field_name"],
+    "get_events": ["event_name", "arm_num", "unique_event_name", "custom_event_label", "event_id"],
+    "get_field_names": ["original_field_name", "choice_value", "export_field_name"],
     "get_instruments": ["instrument_name", "instrument_label"],
     "get_form_event_mappings": ["arm_num", "unique_event_name", "form"],
     "get_repeating_forms_events": ["event_name", "form_name", "custom_form_label"],

--- a/redcaplite/api/schemas.py
+++ b/redcaplite/api/schemas.py
@@ -10,8 +10,8 @@ CSV_EMPTY_SCHEMAS: Dict[str, List[str]] = {
     "get_instruments": ["instrument_name", "instrument_label"],
     "get_form_event_mappings": ["arm_num", "unique_event_name", "form"],
     "get_repeating_forms_events": ["event_name", "form_name", "custom_form_label"],
-    "get_user_roles": ["unique_role_name", "role_label"],
-    "get_user_role_mappings": ["username", "unique_role_name"],
+    "get_user_roles": ["unique_role_name", "role_label", "design", "alerts", "user_rights", "data_access_groups", "reports", "stats_and_charts", "manage_survey_participants", "calendar", "data_import_tool", "data_comparison_tool", "logging", "email_logging", "file_repository", "data_quality_create", "data_quality_execute", "api_export", "api_import", "api_modules", "mobile_app", "mobile_app_download_data", "record_create", "record_rename", "record_delete", "lock_records_customization", "lock_records", "lock_records_all_forms", "forms", "forms_export", "data_quality_resolution"],
+    "get_user_role_mappings": ["username", "unique_role_name", "data_access_group"],
 }
 
 

--- a/redcaplite/api/schemas.py
+++ b/redcaplite/api/schemas.py
@@ -10,6 +10,8 @@ CSV_EMPTY_SCHEMAS: Dict[str, List[str]] = {
     "get_instruments": ["instrument_name", "instrument_label"],
     "get_form_event_mappings": ["arm_num", "unique_event_name", "form"],
     "get_repeating_forms_events": ["event_name", "form_name", "custom_form_label"],
+    "get_user_roles": ["unique_role_name", "role_label"],
+    "get_user_role_mappings": ["username", "unique_role_name"],
 }
 
 

--- a/redcaplite/api/schemas.py
+++ b/redcaplite/api/schemas.py
@@ -1,0 +1,17 @@
+from typing import Dict, List
+
+
+CSV_EMPTY_SCHEMAS: Dict[str, List[str]] = {
+    "get_arms": ["arm_num", "name"],
+    "get_dags": ["data_access_group_name", "unique_group_name"],
+    "get_user_dag_mappings": ["username", "redcap_data_access_group"],
+    "get_events": ["event_name", "arm_num", "unique_event_name"],
+    "get_field_names": ["original_field_name", "export_field_name"],
+    "get_instruments": ["instrument_name", "instrument_label"],
+    "get_form_event_mappings": ["arm_num", "unique_event_name", "form"],
+    "get_repeating_forms_events": ["event_name", "form_name", "custom_form_label"],
+}
+
+
+def get_empty_csv_columns(endpoint_name: str) -> List[str]:
+    return list(CSV_EMPTY_SCHEMAS.get(endpoint_name, []))

--- a/redcaplite/http/client.py
+++ b/redcaplite/http/client.py
@@ -1,3 +1,5 @@
+from typing import Optional, Sequence
+
 import requests
 import redcaplite.http.handler as hd
 
@@ -7,7 +9,13 @@ class Client:
         self.url = url
         self.token = token
 
-    def post(self, data, pd_read_csv_kwargs=None, output_file=None):
+    def post(
+        self,
+        data,
+        pd_read_csv_kwargs=None,
+        output_file=None,
+        empty_columns: Optional[Sequence[str]] = None,
+    ):
         if pd_read_csv_kwargs is None:
             pd_read_csv_kwargs = {}
         format = data.get("format", None)
@@ -16,6 +24,7 @@ class Client:
                 data,
                 pd_read_csv_kwargs=pd_read_csv_kwargs,
                 output_file=output_file,
+                empty_columns=empty_columns,
             )
         elif format == 'json':
             response = self.__json_api(data, output_file=output_file)

--- a/redcaplite/http/handler.py
+++ b/redcaplite/http/handler.py
@@ -3,7 +3,7 @@ import os
 import io
 import pandas as pd
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Sequence, Union
 
 
 def output_handler(func):
@@ -57,7 +57,13 @@ def response_error_handler(func):
 
 
 def csv_handler(func):
-    def wrapper(obj, data, pd_read_csv_kwargs=None, output_file=None):
+    def wrapper(
+        obj,
+        data,
+        pd_read_csv_kwargs=None,
+        output_file=None,
+        empty_columns: Optional[Sequence[str]] = None,
+    ):
         if pd_read_csv_kwargs is None:
             pd_read_csv_kwargs = {}
         data['format'] = 'csv'
@@ -65,7 +71,7 @@ def csv_handler(func):
         if 'returnContent' in data and data['returnContent'] == 'ids':
             return response.json()
         if response.text.strip() == '':
-            return pd.DataFrame()  # Return an empty DataFrame if response is empty
+            return pd.DataFrame(columns=empty_columns)
         io_string = io.StringIO(response.text)
         df = pd.read_csv(io_string, **pd_read_csv_kwargs)
         io_string.close()

--- a/redcaplite/redcap.py
+++ b/redcaplite/redcap.py
@@ -1,4 +1,5 @@
 from redcaplite import api
+from redcaplite.api.schemas import get_empty_csv_columns
 from .http import Client
 from typing import List, Optional, Dict, Any, Union, Literal
 from datetime import datetime
@@ -44,6 +45,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_arms({"arms": arms, "format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_arms"),
         )
 
     def import_arms(
@@ -92,6 +94,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_dags({"format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_dags"),
         )
 
     def import_dags(self, data: RedcapDataType):
@@ -149,6 +152,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_user_dag_mappings({"format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_user_dag_mappings"),
         )
 
     def import_user_dag_mappings(self, data: RedcapDataType):
@@ -184,6 +188,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_events({"arms": arms, "format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_events"),
         )
 
     def import_events(self, data: RedcapDataType):
@@ -231,6 +236,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_field_names({"field": field, "format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_field_names"),
         )
 
     # file
@@ -436,6 +442,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_instruments({"format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_instruments"),
         )
 
     # pdf
@@ -499,6 +506,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_form_event_mappings({"arms": arms, "format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_form_event_mappings"),
         )
 
     def import_form_event_mappings(self, data: RedcapDataType):
@@ -935,6 +943,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_repeating_forms_events({"format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_repeating_forms_events"),
         )
 
     def import_repeating_forms_events(self, data: RedcapDataType):

--- a/redcaplite/redcap.py
+++ b/redcaplite/redcap.py
@@ -1205,6 +1205,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_user_roles({"format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_user_roles"),
         )
 
     def import_user_roles(self, data: RedcapDataType):
@@ -1250,6 +1251,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_user_role_mappings({"format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_user_role_mappings"),
         )
 
     def import_user_role_mappings(self, data: RedcapDataType):

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -27,20 +27,32 @@ def test_client_post_csv():
         response = client.post({'format': 'csv'})
         assert response == mock_response
         mock_csv_api.assert_called_once_with(
-            {'format': 'csv'}, pd_read_csv_kwargs={}, output_file=None)
+            {'format': 'csv'},
+            pd_read_csv_kwargs={},
+            output_file=None,
+            empty_columns=None,
+        )
 
     with patch.object(client, '_Client__csv_api', return_value=mock_response) as mock_csv_api:
         response = client.post(
             {'format': 'csv'}, pd_read_csv_kwargs={"foo": []})
         assert response == mock_response
         mock_csv_api.assert_called_once_with(
-            {'format': 'csv'}, pd_read_csv_kwargs={"foo": []}, output_file=None)
+            {'format': 'csv'},
+            pd_read_csv_kwargs={"foo": []},
+            output_file=None,
+            empty_columns=None,
+        )
 
     with patch.object(client, '_Client__csv_api', return_value=mock_response) as mock_csv_api:
         response = client.post({'format': 'csv'}, output_file='records.csv')
         assert response == mock_response
         mock_csv_api.assert_called_once_with(
-            {'format': 'csv'}, pd_read_csv_kwargs={}, output_file='records.csv')
+            {'format': 'csv'},
+            pd_read_csv_kwargs={},
+            output_file='records.csv',
+            empty_columns=None,
+        )
 
 
 def test_client_post_json_with_output_file():
@@ -111,3 +123,21 @@ def test_client_file_upload_api():
             response = client.file_upload_api('file.txt', {})
             assert response == mock_response
             mock_file.assert_called_once_with('file.txt', 'rb')
+
+
+def test_client_post_csv_with_empty_columns():
+    """Test Client post method forwards empty schema columns for CSV."""
+    client = Client('https://example.com', 'token')
+    mock_response = Mock()
+    with patch.object(client, '_Client__csv_api', return_value=mock_response) as mock_csv_api:
+        response = client.post(
+            {'format': 'csv'},
+            empty_columns=["arm_num", "name"],
+        )
+        assert response == mock_response
+        mock_csv_api.assert_called_once_with(
+            {'format': 'csv'},
+            pd_read_csv_kwargs={},
+            output_file=None,
+            empty_columns=["arm_num", "name"],
+        )

--- a/tests/http/test_handler.py
+++ b/tests/http/test_handler.py
@@ -123,6 +123,16 @@ def test_csv_handler_return_empty():
         response, pd.DataFrame())
 
 
+def test_csv_handler_return_empty_with_columns():
+    """Test csv_handler decorator returns schema-aware empty DataFrame."""
+    mock_func = Mock(return_value=Mock(text='\n'))
+    decorated_func = csv_handler(mock_func)
+    response = decorated_func(None, {}, empty_columns=["arm_num", "name"])
+    assert isinstance(response, pd.DataFrame)
+    pd.testing.assert_frame_equal(
+        response, pd.DataFrame(columns=["arm_num", "name"]))
+
+
 def test_csv_handler_csv_reader():
     """Test csv_handler decorator"""
     mock_func = Mock(return_value=Mock(text='csv data,date\n04,005'))

--- a/tests/test_redcap.py
+++ b/tests/test_redcap.py
@@ -708,6 +708,17 @@ def test_get_user_roles(client):
     )
 
 
+def test_get_user_roles_forwards_empty_columns(client):
+    """Test get_user_roles forwards schema columns for empty CSV responses."""
+    with patch.object(client, 'post', return_value=Mock()) as mock_post:
+        client.get_user_roles(format='csv')
+        mock_post.assert_called_once_with(
+            {'content': 'userRole', 'format': 'csv'},
+            output_file=None,
+            empty_columns=['unique_role_name', 'role_label'],
+        )
+
+
 def test_import_user_roles_with_kwargs(client):
     mock_redcap_client_post(
         client, 'import_user_roles',
@@ -735,6 +746,17 @@ def test_redcap_client_get_user_role_mappings(client):
         expected_requests_data={'content': 'userRoleMapping',
                                 'format': 'json', 'returnFormat': 'json', 'token': 'token'},
     )
+
+
+def test_redcap_client_get_user_role_mappings_forwards_empty_columns(client):
+    """Test get_user_role_mappings forwards schema columns for empty CSV responses."""
+    with patch.object(client, 'post', return_value=Mock()) as mock_post:
+        client.get_user_role_mappings(format='csv')
+        mock_post.assert_called_once_with(
+            {'content': 'userRoleMapping', 'format': 'csv'},
+            output_file=None,
+            empty_columns=['username', 'unique_role_name'],
+        )
 
 
 def test_redcap_client_import_user_role_mappings(client):

--- a/tests/test_redcap.py
+++ b/tests/test_redcap.py
@@ -756,7 +756,7 @@ def test_redcap_client_get_user_role_mappings_forwards_empty_columns(client):
         mock_post.assert_called_once_with(
             {'content': 'userRoleMapping', 'format': 'csv'},
             output_file=None,
-            empty_columns=get_empty_csv_columns('get_user_role_mappings'),
+            empty_columns=["username", "unique_role_name", "data_access_group"],
         )
 
 

--- a/tests/test_redcap.py
+++ b/tests/test_redcap.py
@@ -716,7 +716,7 @@ def test_get_user_roles_forwards_empty_columns(client):
         mock_post.assert_called_once_with(
             {'content': 'userRole', 'format': 'csv'},
             output_file=None,
-            empty_columns=get_empty_csv_columns('get_user_roles'),
+            empty_columns=["unique_role_name", "role_label", "design", "alerts", "user_rights", "data_access_groups", "reports", "stats_and_charts", "manage_survey_participants", "calendar", "data_import_tool", "data_comparison_tool", "logging", "email_logging", "file_repository", "data_quality_create", "data_quality_execute", "api_export", "api_import", "api_modules", "mobile_app", "mobile_app_download_data", "record_create", "record_rename", "record_delete", "lock_records_customization", "lock_records", "lock_records_all_forms", "forms", "forms_export", "data_quality_resolution"],
         )
 
 

--- a/tests/test_redcap.py
+++ b/tests/test_redcap.py
@@ -91,6 +91,17 @@ def test_redcap_client_delete_arms(client):
     )
 
 
+def test_redcap_client_get_arms_forwards_empty_columns(client):
+    """Test get_arms forwards schema columns for empty CSV responses."""
+    with patch.object(client, 'post', return_value=Mock()) as mock_post:
+        client.get_arms(format='csv')
+        mock_post.assert_called_once_with(
+            {'content': 'arm', 'format': 'csv'},
+            output_file=None,
+            empty_columns=['arm_num', 'name'],
+        )
+
+
 # Dags
 def test_redcap_client_get_dags(client):
     """Test RedcapClient get_dags method"""

--- a/tests/test_redcap.py
+++ b/tests/test_redcap.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import Mock, patch, mock_open
 from redcaplite import RedcapClient
+from redcaplite.api.schemas import get_empty_csv_columns
 import pandas as pd
 import numpy as np
 from pandas.testing import assert_frame_equal
@@ -715,7 +716,7 @@ def test_get_user_roles_forwards_empty_columns(client):
         mock_post.assert_called_once_with(
             {'content': 'userRole', 'format': 'csv'},
             output_file=None,
-            empty_columns=['unique_role_name', 'role_label'],
+            empty_columns=get_empty_csv_columns('get_user_roles'),
         )
 
 
@@ -755,7 +756,7 @@ def test_redcap_client_get_user_role_mappings_forwards_empty_columns(client):
         mock_post.assert_called_once_with(
             {'content': 'userRoleMapping', 'format': 'csv'},
             output_file=None,
-            empty_columns=['username', 'unique_role_name'],
+            empty_columns=get_empty_csv_columns('get_user_role_mappings'),
         )
 
 


### PR DESCRIPTION
### Motivation
- Preserve and simplify legacy handling for blank CSV responses by returning a zero-row `DataFrame` with known columns when schema metadata is available.
- Centralize CSV-empty schema definitions so fixed-schema exports can consistently return schema-aware empty results without ad-hoc branching.
- Reduce branching in CSV forwarding by always passing `empty_columns` through the HTTP client/handler pipeline.

### Description
- Added a centralized CSV schema registry in `redcaplite/api/schemas.py` with `CSV_EMPTY_SCHEMAS` and `get_empty_csv_columns` to expose known empty-column lists for fixed endpoints.
- Modified `redcaplite/http/handler.py` `csv_handler` to accept `empty_columns` and return `pd.DataFrame(columns=empty_columns)` for blank CSV responses instead of an undifferentiated empty `DataFrame`.
- Extended `redcaplite/http/client.py` `Client.post` signature to accept `empty_columns` and always forward it to the internal `__csv_api` call.
- Wired many `RedcapClient` export methods in `redcaplite/redcap.py` to call `get_empty_csv_columns(...)` and forward the result as `empty_columns` when invoking `post` for CSV-capable endpoints.
- Updated `CHANGELOG.md` to document the behavior changes and new tests.
- Added/updated unit tests covering forwarding of `empty_columns` and schema-aware empty CSV handling in `tests/http/test_client.py`, `tests/http/test_handler.py`, and `tests/test_redcap.py`.

### Testing
- Ran unit tests under `tests/http/test_client.py` which include `test_client_post_csv_with_empty_columns` and all client post tests; they passed.
- Ran handler tests in `tests/http/test_handler.py` including `test_csv_handler_return_empty_with_columns` and CSV parsing cases; they passed.
- Ran `tests/test_redcap.py` which includes `test_redcap_client_get_arms_forwards_empty_columns` and related RedcapClient coverage; they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dff30c06348330a24e14876d5d6d33)