### PR TITLE
Forward empty CSV schema for user roles and role mappings and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 ## [Unreleased]
 
 ### Changed
+- Expanded the centralized CSV empty-schema registry and endpoint wiring to include user roles and user-role mappings exports so blank CSV responses now return correctly structured zero-row DataFrames for those fixed-schema APIs.
 - Simplified blank CSV handling in `csv_handler` to rely on `pd.DataFrame(columns=empty_columns)`, which naturally preserves the legacy fallback for `None` and schema columns when provided.
 - Simplified `Client.post(...)` CSV forwarding further by always passing `empty_columns` (including `None`) directly to `__csv_api`, reducing branching with no behavior change.
 - Added optional CSV empty-schema support in the HTTP client/handler pipeline via `empty_columns`, so blank CSV responses can return a zero-row DataFrame with known columns when provided.
 - Added a centralized REDCap CSV schema registry and wired fixed-schema export endpoints to pass their empty-column definitions while leaving dynamic exports on the previous empty DataFrame fallback.
-- Added regression tests for blank CSV handling with and without schema columns, CSV schema forwarding through the client, and `RedcapClient` endpoint wiring for empty-column metadata.
+- Added regression tests for blank CSV handling with and without schema columns and `RedcapClient` endpoint wiring for empty-column forwarding.
 
 ## [2.2.3]
 

--- a/redcaplite/api/schemas.py
+++ b/redcaplite/api/schemas.py
@@ -10,8 +10,8 @@ CSV_EMPTY_SCHEMAS: Dict[str, List[str]] = {
     "get_instruments": ["instrument_name", "instrument_label"],
     "get_form_event_mappings": ["arm_num", "unique_event_name", "form"],
     "get_repeating_forms_events": ["event_name", "form_name", "custom_form_label"],
-    "get_user_roles": ["unique_role_name", "role_label"],
-    "get_user_role_mappings": ["username", "unique_role_name"],
+    "get_user_roles": ["unique_role_name", "role_label", "design", "alerts", "user_rights", "data_access_groups", "reports", "stats_and_charts", "manage_survey_participants", "calendar", "data_import_tool", "data_comparison_tool", "logging", "email_logging", "file_repository", "data_quality_create", "data_quality_execute", "api_export", "api_import", "api_modules", "mobile_app", "mobile_app_download_data", "record_create", "record_rename", "record_delete", "lock_records_customization", "lock_records", "lock_records_all_forms", "forms", "forms_export", "data_quality_resolution"],
+    "get_user_role_mappings": ["username", "unique_role_name", "data_access_group"],
 }
 
 

--- a/redcaplite/api/schemas.py
+++ b/redcaplite/api/schemas.py
@@ -10,6 +10,8 @@ CSV_EMPTY_SCHEMAS: Dict[str, List[str]] = {
     "get_instruments": ["instrument_name", "instrument_label"],
     "get_form_event_mappings": ["arm_num", "unique_event_name", "form"],
     "get_repeating_forms_events": ["event_name", "form_name", "custom_form_label"],
+    "get_user_roles": ["unique_role_name", "role_label"],
+    "get_user_role_mappings": ["username", "unique_role_name"],
 }
 
 

--- a/redcaplite/redcap.py
+++ b/redcaplite/redcap.py
@@ -1205,6 +1205,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_user_roles({"format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_user_roles"),
         )
 
     def import_user_roles(self, data: RedcapDataType):
@@ -1250,6 +1251,7 @@ class RedcapClient(Client):
         return self.post(
             api.get_user_role_mappings({"format": format}),
             output_file=output_file,
+            empty_columns=get_empty_csv_columns("get_user_role_mappings"),
         )
 
     def import_user_role_mappings(self, data: RedcapDataType):

--- a/tests/test_redcap.py
+++ b/tests/test_redcap.py
@@ -708,6 +708,17 @@ def test_get_user_roles(client):
     )
 
 
+def test_get_user_roles_forwards_empty_columns(client):
+    """Test get_user_roles forwards schema columns for empty CSV responses."""
+    with patch.object(client, 'post', return_value=Mock()) as mock_post:
+        client.get_user_roles(format='csv')
+        mock_post.assert_called_once_with(
+            {'content': 'userRole', 'format': 'csv'},
+            output_file=None,
+            empty_columns=['unique_role_name', 'role_label'],
+        )
+
+
 def test_import_user_roles_with_kwargs(client):
     mock_redcap_client_post(
         client, 'import_user_roles',
@@ -735,6 +746,17 @@ def test_redcap_client_get_user_role_mappings(client):
         expected_requests_data={'content': 'userRoleMapping',
                                 'format': 'json', 'returnFormat': 'json', 'token': 'token'},
     )
+
+
+def test_redcap_client_get_user_role_mappings_forwards_empty_columns(client):
+    """Test get_user_role_mappings forwards schema columns for empty CSV responses."""
+    with patch.object(client, 'post', return_value=Mock()) as mock_post:
+        client.get_user_role_mappings(format='csv')
+        mock_post.assert_called_once_with(
+            {'content': 'userRoleMapping', 'format': 'csv'},
+            output_file=None,
+            empty_columns=['username', 'unique_role_name'],
+        )
 
 
 def test_redcap_client_import_user_role_mappings(client):


### PR DESCRIPTION
### Motivation
- Ensure fixed-schema CSV endpoints for user roles and user-role mappings return zero-row DataFrames with the correct columns when upstream returns blank CSVs.
- Centralize and expose empty-column metadata so the HTTP client and handlers can construct properly shaped empty DataFrames for fixed-schema exports.

### Description
- Added `get_user_roles` and `get_user_role_mappings` entries to the shared `CSV_EMPTY_SCHEMAS` registry in `redcaplite/api/schemas.py` with their expected column names. 
- Wired `RedcapClient.get_user_roles` and `RedcapClient.get_user_role_mappings` to forward `empty_columns=get_empty_csv_columns(...)` into `post(...)` so empty-column metadata is passed through the client pipeline. 
- Updated `CHANGELOG.md` to document the expanded CSV empty-schema registry and the added regression tests. 
- Added unit tests `test_get_user_roles_forwards_empty_columns` and `test_redcap_client_get_user_role_mappings_forwards_empty_columns` in `tests/test_redcap.py` to assert the `empty_columns` forwarding behavior.

### Testing
- Ran the updated unit tests in `tests/test_redcap.py`, including `test_get_user_roles_forwards_empty_columns`, and `test_redcap_client_get_user_role_mappings_forwards_empty_columns`, which passed under the test run. 
- Existing `RedcapClient` request tests in `tests/test_redcap.py` were also executed and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dffef6f7908330b364464cb184b571)