### PR TITLE
Release v2.3.0 — CSV empty-schema support and test alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 ## [Unreleased]
 
 ### Changed
+- Aligned user-role CSV forwarding tests with the expanded fixed-schema column definitions used by the client for empty CSV responses.
+
+## [2.3.0]
+
+### Changed
 - Expanded the centralized CSV empty-schema registry and endpoint wiring to include user roles and user-role mappings exports so blank CSV responses now return correctly structured zero-row DataFrames for those fixed-schema APIs.
 - Simplified blank CSV handling in `csv_handler` to rely on `pd.DataFrame(columns=empty_columns)`, which naturally preserves the legacy fallback for `None` and schema columns when provided.
 - Simplified `Client.post(...)` CSV forwarding further by always passing `empty_columns` (including `None`) directly to `__csv_api`, reducing branching with no behavior change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,11 @@ The format is based on Keep a Changelog, with entries listed in reverse chronolo
 
 ## [Unreleased]
 
-### Changed
-- Aligned user-role CSV forwarding tests with the expanded fixed-schema column definitions used by the client for empty CSV responses.
 
 ## [2.3.0]
 
 ### Changed
+- Aligned user-role CSV forwarding tests with the expanded fixed-schema column definitions used by the client for empty CSV responses.
 - Expanded the centralized CSV empty-schema registry and endpoint wiring to include user roles and user-role mappings exports so blank CSV responses now return correctly structured zero-row DataFrames for those fixed-schema APIs.
 - Simplified blank CSV handling in `csv_handler` to rely on `pd.DataFrame(columns=empty_columns)`, which naturally preserves the legacy fallback for `None` and schema columns when provided.
 - Simplified `Client.post(...)` CSV forwarding further by always passing `empty_columns` (including `None`) directly to `__csv_api`, reducing branching with no behavior change.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 `redcaplite` helps you connect to REDCap projects and perform common API and CLI workflows from one package. Whether you're a researcher automating data pulls or a developer building integrations, `redcaplite` supports both scripted API usage and command-line operations.
 
-## ✨ v2.2.3 – JSON-default export helper alignment
+## ✨ v2.3.0 – CSV empty-schema support and handler simplification
 
-Version 2.2.3 aligns `RedcapClient` JSON-default export helper signatures with API format defaults by explicitly exposing and forwarding `format` options while preserving the command-first CLI style (`rcl <command> <profile> ...`).
+Version 2.3.0 expands empty CSV handling with endpoint-aware schema defaults, so fixed-schema exports now return zero-row DataFrames with expected columns while dynamic exports preserve legacy fallback behavior.
 
 The CLI provides:
 - Profile-based access (`rcl <command> <profile> ...`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcaplite"
-version = "2.2.3"
+version = "2.3.0"
 authors = [
   { name="Jubilee Tan", email="jubilee2@gmail.com" },
 ]

--- a/tests/test_redcap.py
+++ b/tests/test_redcap.py
@@ -756,7 +756,7 @@ def test_redcap_client_get_user_role_mappings_forwards_empty_columns(client):
         mock_post.assert_called_once_with(
             {'content': 'userRoleMapping', 'format': 'csv'},
             output_file=None,
-            empty_columns=get_empty_csv_columns('get_user_role_mappings'),
+            empty_columns=["username", "unique_role_name", "data_access_group"],
         )
 
 

--- a/tests/test_redcap.py
+++ b/tests/test_redcap.py
@@ -716,7 +716,7 @@ def test_get_user_roles_forwards_empty_columns(client):
         mock_post.assert_called_once_with(
             {'content': 'userRole', 'format': 'csv'},
             output_file=None,
-            empty_columns=get_empty_csv_columns('get_user_roles'),
+            empty_columns=["unique_role_name", "role_label", "design", "alerts", "user_rights", "data_access_groups", "reports", "stats_and_charts", "manage_survey_participants", "calendar", "data_import_tool", "data_comparison_tool", "logging", "email_logging", "file_repository", "data_quality_create", "data_quality_execute", "api_export", "api_import", "api_modules", "mobile_app", "mobile_app_download_data", "record_create", "record_rename", "record_delete", "lock_records_customization", "lock_records", "lock_records_all_forms", "forms", "forms_export", "data_quality_resolution"],
         )
 
 

--- a/tests/test_redcap.py
+++ b/tests/test_redcap.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import Mock, patch, mock_open
 from redcaplite import RedcapClient
+from redcaplite.api.schemas import get_empty_csv_columns
 import pandas as pd
 import numpy as np
 from pandas.testing import assert_frame_equal
@@ -715,7 +716,7 @@ def test_get_user_roles_forwards_empty_columns(client):
         mock_post.assert_called_once_with(
             {'content': 'userRole', 'format': 'csv'},
             output_file=None,
-            empty_columns=['unique_role_name', 'role_label'],
+            empty_columns=get_empty_csv_columns('get_user_roles'),
         )
 
 
@@ -755,7 +756,7 @@ def test_redcap_client_get_user_role_mappings_forwards_empty_columns(client):
         mock_post.assert_called_once_with(
             {'content': 'userRoleMapping', 'format': 'csv'},
             output_file=None,
-            empty_columns=['username', 'unique_role_name'],
+            empty_columns=get_empty_csv_columns('get_user_role_mappings'),
         )
 
 


### PR DESCRIPTION
### Motivation
- Provide a new 2.3.0 release that documents and ships CSV empty-schema and handler simplifications so fixed-schema REDCap exports return zero-row DataFrames with expected columns.
- Align tests and documentation with the runtime behavior that forwards endpoint-specific empty-column definitions from the centralized schema registry.

### Description
- Bumped the package version to `2.3.0` in project metadata (`pyproject.toml`) to mark the release.【F:pyproject.toml†L1-L4】
- Promoted the previous `[Unreleased]` changelog entries into a new `## [2.3.0]` section and added a short unreleased maintenance note about test alignment (`CHANGELOG.md`).【F:CHANGELOG.md†L7-L20】
- Updated the README release highlight to describe the v2.3.0 CSV empty-schema support and handler simplification (`README.md`).【F:README.md†L13-L16】
- Updated tests to assert against the centralized empty-column registry by importing and using `get_empty_csv_columns(...)` in `tests/test_redcap.py` so user-role CSV forwarding expectations match the client behavior.【F:tests/test_redcap.py†L4】【F:tests/test_redcap.py†L712-L720】【F:tests/test_redcap.py†L752-L760】

### Testing
- Running `pytest` initially revealed two failing assertions related to user-role empty-column expectations before the tests were aligned (see failing assertions in the first run).【T:pytest†initial run — 2 failed】
- After updating the tests, `pytest` completed successfully with `228 passed, 21 skipped`.【T:pytest†final run — 228 passed, 21 skipped】

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e0021c8cd88330b47dab62462c3191)